### PR TITLE
V1

### DIFF
--- a/adjuster.go
+++ b/adjuster.go
@@ -1,0 +1,95 @@
+package velty
+
+import "github.com/viant/velty/ast"
+
+// Patch represents a textual replacement for a span.
+type Patch struct {
+	Span        Span
+	Replacement []byte
+}
+
+// ActionKind describes the result of an adjuster.
+type ActionKind int
+
+const (
+	ActionKeep ActionKind = iota
+	ActionReplace
+	ActionRemove
+	ActionPatchOnly
+)
+
+// Action is the result returned by an adjuster.
+type Action struct {
+	Kind         ActionKind
+	Node         ast.Node // for replace
+	Patches      []Patch  // optional patches
+	SkipChildren bool     // skip walking children of this node
+}
+
+// Helpers
+func Keep() Action              { return Action{Kind: ActionKeep} }
+func Replace(n ast.Node) Action { return Action{Kind: ActionReplace, Node: n} }
+func Remove() Action            { return Action{Kind: ActionRemove} }
+func PatchSpan(s Span, repl []byte) Action {
+	return Action{Kind: ActionPatchOnly, Patches: []Patch{{Span: s, Replacement: repl}}}
+}
+func (a Action) WithSkipChildren() Action { a.SkipChildren = true; return a }
+
+// NodeAdjuster defines a transformation applied to AST nodes.
+type NodeAdjuster interface {
+	// Adjust applies transformations to the given node within the parser context.
+	// It returns an action or error.
+	Adjust(node ast.Node, ctx *ParserContext) (Action, error)
+}
+
+// AdjustFunc is a helper to define NodeAdjuster via a function.
+type AdjustFunc func(node ast.Node, ctx *ParserContext) (Action, error)
+
+// Adjust implements NodeAdjuster for AdjustFunc.
+func (f AdjustFunc) Adjust(node ast.Node, ctx *ParserContext) (Action, error) {
+	return f(node, ctx)
+}
+
+// AdjusterChain applies multiple NodeAdjusters in sequence.
+type AdjusterChain struct {
+	Adjusters []NodeAdjuster
+}
+
+// NewAdjusterChain constructs a chain of NodeAdjusters.
+func NewAdjusterChain(adjusters ...NodeAdjuster) *AdjusterChain {
+	return &AdjusterChain{Adjusters: adjusters}
+}
+
+// Adjust runs each adjuster on the node in order, passing the parser context.
+// It merges patches and respects removal and replace.
+func (c *AdjusterChain) Adjust(node ast.Node, ctx *ParserContext) (Action, error) {
+	result := Keep()
+	curr := node
+	for _, adj := range c.Adjusters {
+		act, err := adj.Adjust(curr, ctx)
+		if err != nil {
+			return Action{}, err
+		}
+		// merge patches
+		if len(act.Patches) > 0 {
+			ctx.AddPatches(act.Patches...)
+		}
+		// respect removal
+		if act.Kind == ActionRemove {
+			return act, nil
+		}
+		// handle replace
+		if act.Kind == ActionReplace {
+			curr = act.Node
+			result = act
+		}
+		// propagate SkipChildren if any
+		if act.SkipChildren {
+			result.SkipChildren = true
+		}
+	}
+	if result.Kind == ActionReplace {
+		return result, nil
+	}
+	return Keep(), nil
+}

--- a/benchmarks/BASELINE_BENCH.txt
+++ b/benchmarks/BASELINE_BENCH.txt
@@ -1,0 +1,48 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/assign
+Benchmark_Exec_Shared-10    	 7646671	       141.7 ns/op	      16 B/op	       1 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/evaluate
+Benchmark_Exec_Direct-10      	 2034057	       575.0 ns/op	    1200 B/op	       4 allocs/op
+Benchmark_Exec_Indirect-10    	 2048505	       572.3 ns/op	    1200 B/op	       4 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/for
+Benchmark_Exec_Direct-10      	 2263370	       522.1 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	 2263562	       527.6 ns/op	       0 B/op	       0 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/foreach
+Benchmark_Exec_Direct-10        	 3319246	       360.9 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10      	 3356926	       361.2 ns/op	       0 B/op	       0 allocs/op
+Benchmark_NewState_Direct-10    	 5285397	       201.8 ns/op	    1168 B/op	       4 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/functions
+Benchmark_Exec_Shared-10    	 5636460	       195.1 ns/op	     224 B/op	       7 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/if
+Benchmark_Exec_Direct-10      	13293734	        91.81 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	14079205	        85.99 ns/op	       0 B/op	       0 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/select
+Benchmark_Exec_Direct-10      	20560766	        57.69 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	21125659	        57.64 ns/op	       0 B/op	       0 allocs/op
+
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/template
+Benchmark_Exec_Velty-10            	   42586	     28730 ns/op	   23040 B/op	     600 allocs/op
+Benchmark_ExecFuncLess_Velty-10    	  121345	      9986 ns/op	       0 B/op	       0 allocs/op
+Benchmark_NewState_Direct-10       	 1242596	       921.7 ns/op	   10448 B/op	       4 allocs/op
+

--- a/benchmarks/CURRENT_BENCH.txt
+++ b/benchmarks/CURRENT_BENCH.txt
@@ -1,0 +1,57 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/assign
+Benchmark_Exec_Shared-10    	 8294526	       142.1 ns/op	      16 B/op	       1 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/assign	1.568s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/evaluate
+Benchmark_Exec_Direct-10      	 1424226	       828.4 ns/op	    1488 B/op	      14 allocs/op
+Benchmark_Exec_Indirect-10    	 1406422	       871.6 ns/op	    1488 B/op	      14 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/evaluate	4.388s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/for
+Benchmark_Exec_Direct-10      	 2248249	       523.2 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	 2270325	       529.0 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/for	3.717s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/foreach
+Benchmark_Exec_Direct-10        	 1581127	       746.7 ns/op	     288 B/op	      12 allocs/op
+Benchmark_Exec_Indirect-10      	 1602817	       750.2 ns/op	     288 B/op	      12 allocs/op
+Benchmark_NewState_Direct-10    	 5180450	       236.9 ns/op	    1216 B/op	       4 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/foreach	5.636s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/functions
+Benchmark_Exec_WithContext-10    	 6691671	       177.0 ns/op	     216 B/op	       7 allocs/op
+Benchmark_Exec_Shared-10         	 6211293	       195.7 ns/op	     224 B/op	       7 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/functions	2.826s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/if
+Benchmark_Exec_Direct-10      	11868339	        93.33 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	12708699	        92.56 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/if	2.724s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/select
+Benchmark_Exec_Direct-10      	20155932	        60.83 ns/op	       0 B/op	       0 allocs/op
+Benchmark_Exec_Indirect-10    	19291130	        60.62 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/select	3.696s
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/velty/bench/template
+Benchmark_Exec_Velty-10            	   34710	     32166 ns/op	   25920 B/op	     720 allocs/op
+Benchmark_ExecFuncLess_Velty-10    	   88392	     14296 ns/op	    2880 B/op	     120 allocs/op
+Benchmark_NewState_Direct-10       	 1000000	      1057 ns/op	   10496 B/op	       4 allocs/op
+PASS
+ok  	github.com/viant/velty/bench/template	4.221s

--- a/compile.go
+++ b/compile.go
@@ -11,9 +11,46 @@ import (
 
 // Compile create Execution Plan and State provider for the Execution Plan.
 func (p *Planner) Compile(template []byte) (*est.Execution, func() *est.State, error) {
-	root, err := parser.Parse(template)
-	if err != nil {
-		return nil, nil, err
+	var (
+		root *stmt.Block
+		err  error
+	)
+
+	hasParserHooks := p.listener != nil || p.adjuster != nil
+
+	if !hasParserHooks {
+		// Fast path: parse without spans and compile directly.
+		root, err = parser.Parse(template)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		// Instrumented path: parse with spans and run listener/adjuster hooks.
+		root, err = parser.ParseWithSpans(template)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Build symbol seeds for resolution helpers
+		params := make([]string, 0)
+		for _, sel := range p.selectors.Selectors() {
+			if sel.Parent == nil && sel.IsFieldSelector {
+				params = append(params, sel.ID)
+			}
+		}
+		namespaces := []string{}
+		funcs := []string{}
+		if p.Functions != nil {
+			namespaces = p.Functions.NamespaceNames()
+			funcs = p.Functions.StandaloneNames()
+		}
+		seeds := &SymbolSeeds{Params: params, Namespaces: namespaces, Standalone: funcs}
+		// apply hooks with evaluate config and seeds; ignore patches here (integrator may use them separately)
+		if transformed, _, err := applyParserHooksWithConfig("", template, root, p.listener, p.adjuster, p.evalConfig, seeds); err == nil && transformed != nil {
+			root = transformed
+		} else if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	exec, err := p.newExecution(root)

--- a/compile.go
+++ b/compile.go
@@ -2,6 +2,7 @@ package velty
 
 import (
 	"context"
+	"github.com/viant/velty/ast"
 	"github.com/viant/velty/ast/stmt"
 	"github.com/viant/velty/est"
 	"github.com/viant/velty/parser"
@@ -26,7 +27,8 @@ func (p *Planner) Compile(template []byte) (*est.Execution, func() *est.State, e
 		}
 	} else {
 		// Instrumented path: parse with spans and run listener/adjuster hooks.
-		root, err = parser.ParseWithSpans(template)
+		var spans map[ast.Node]parser.NodeSpan
+		root, spans, err = parser.ParseWithSpansDetailed(template)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -46,7 +48,10 @@ func (p *Planner) Compile(template []byte) (*est.Execution, func() *est.State, e
 		}
 		seeds := &SymbolSeeds{Params: params, Namespaces: namespaces, Standalone: funcs}
 		// apply hooks with evaluate config and seeds; ignore patches here (integrator may use them separately)
-		if transformed, _, err := applyParserHooksWithConfig("", template, root, p.listener, p.adjuster, p.evalConfig, seeds); err == nil && transformed != nil {
+		hookCtx := &ParserContext{Scope: NewScope(nil)}
+		hookCtx.InitSource("", template)
+		hookCtx.EvalConfig = p.evalConfig
+		if transformed, _, err := applyParserHooksWithConfigAndSpans(hookCtx, root, p.listener, p.adjuster, spans, seeds); err == nil && transformed != nil {
 			root = transformed
 		} else if err != nil {
 			return nil, nil, err

--- a/context_listener_test.go
+++ b/context_listener_test.go
@@ -1,0 +1,167 @@
+package velty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	aexpr "github.com/viant/velty/ast/expr"
+	"github.com/viant/velty/parser"
+)
+
+type ctxCaptureListener struct{ events []Event }
+
+func (c *ctxCaptureListener) OnEvent(e Event) { c.events = append(c.events, e) }
+
+func TestExprContext_BasicPatterns(t *testing.T) {
+	t.Run("if_condition_selector", func(t *testing.T) {
+		tpl := []byte("#if($X)ok#end")
+		cap := &ctxCaptureListener{}
+		root, err := parser.ParseWithSpans(tpl)
+		require.NoError(t, err)
+		_, _, err = applyParserHooksWithConfig("", tpl, root, cap, nil, EvaluateConfig{})
+		require.NoError(t, err)
+
+		var selCtx ExprContextKind
+		for _, ev := range cap.events {
+			if ev.Type != EventEnterNode {
+				continue
+			}
+			if _, ok := ev.Node.(*aexpr.Select); ok {
+				selCtx = ev.ExprContext.Kind
+				break
+			}
+		}
+		require.Equal(t, CtxIfCond, selCtx, "selector in #if condition should be CtxIfCond")
+	})
+
+	t.Run("foreach_iterable_and_body", func(t *testing.T) {
+		tpl := []byte("#foreach($x in $items)$x#end")
+		cap := &ctxCaptureListener{}
+		root, err := parser.ParseWithSpans(tpl)
+		require.NoError(t, err)
+		_, _, err = applyParserHooksWithConfig("", tpl, root, cap, nil, EvaluateConfig{})
+		require.NoError(t, err)
+
+		var iterCtx, bodyCtx ExprContextKind
+		foundIter := false
+		foundBody := false
+		for _, ev := range cap.events {
+			if ev.Type != EventEnterNode {
+				continue
+			}
+			if sel, ok := ev.Node.(*aexpr.Select); ok {
+				switch sel.ID {
+				case "items":
+					iterCtx = ev.ExprContext.Kind
+					foundIter = true
+				case "x":
+					bodyCtx = ev.ExprContext.Kind
+					foundBody = true
+				}
+			}
+		}
+		require.True(t, foundIter, "foreach iterable selector not found")
+		require.True(t, foundBody, "foreach body selector not found")
+		require.Equal(t, CtxForEachCond, iterCtx, "foreach set expression should be CtxForEachCond")
+		require.Equal(t, CtxForEachBody, bodyCtx, "foreach body selector should be CtxForEachBody")
+	})
+
+	t.Run("set_lhs_rhs", func(t *testing.T) {
+		tpl := []byte("#set($x = $y)")
+		cap := &ctxCaptureListener{}
+		root, err := parser.ParseWithSpans(tpl)
+		require.NoError(t, err)
+		_, _, err = applyParserHooksWithConfig("", tpl, root, cap, nil, EvaluateConfig{})
+		require.NoError(t, err)
+
+		var lhsCtx, rhsCtx ExprContextKind
+		for _, ev := range cap.events {
+			if ev.Type != EventEnterNode {
+				continue
+			}
+			sel, ok := ev.Node.(*aexpr.Select)
+			if !ok {
+				continue
+			}
+			switch sel.ID {
+			case "x":
+				lhsCtx = ev.ExprContext.Kind
+			case "y":
+				rhsCtx = ev.ExprContext.Kind
+			}
+		}
+		require.Equal(t, CtxSetLHS, lhsCtx, "set LHS should be CtxSetLHS")
+		require.Equal(t, CtxSetRHS, rhsCtx, "set RHS should be CtxSetRHS")
+	})
+
+	t.Run("call_arguments", func(t *testing.T) {
+		// TODO: add a stable call-arg context test once
+		// function/method call shapes are finalized for instrumentation.
+	})
+
+	t.Run("evaluate_expression_context", func(t *testing.T) {
+		tpl := []byte("#evaluate(\"$X\")")
+		cap := &ctxCaptureListener{}
+		root, err := parser.ParseWithSpans(tpl)
+		require.NoError(t, err)
+		evalCfg := EvaluateConfig{Mode: EvalInspect}
+		_, _, err = applyParserHooksWithConfig("", tpl, root, cap, nil, evalCfg)
+		require.NoError(t, err)
+
+		var evalCtx ExprContextKind
+		for _, ev := range cap.events {
+			if ev.Type != EventEnterNode {
+				continue
+			}
+			if _, ok := ev.Node.(*aexpr.Select); ok {
+				evalCtx = ev.ExprContext.Kind
+				break
+			}
+		}
+		require.Equal(t, CtxEvaluate, evalCtx, "selector inside #evaluate should be CtxEvaluate")
+	})
+
+	// TODO: add explicit elseif/else and for-loop
+	// context assertions once the parser representation
+	// and walker semantics are fully locked in.
+
+	t.Run("varkind_and_occurrence", func(t *testing.T) {
+		tpl := []byte("$P $P #set($l = $P) $l")
+		cap := &ctxCaptureListener{}
+		root, err := parser.ParseWithSpans(tpl)
+		require.NoError(t, err)
+		seeds := &SymbolSeeds{Params: []string{"P"}}
+		_, _, err = applyParserHooksWithConfig("", tpl, root, cap, nil, EvaluateConfig{}, seeds)
+		require.NoError(t, err)
+
+		counts := map[string][]Event{}
+		for _, ev := range cap.events {
+			if ev.Type != EventEnterNode {
+				continue
+			}
+			sel, ok := ev.Node.(*aexpr.Select)
+			if !ok {
+				continue
+			}
+			counts[sel.ID] = append(counts[sel.ID], ev)
+		}
+
+		// P should be classified as VarParam
+		pEvents := counts["P"]
+		require.GreaterOrEqual(t, len(pEvents), 3)
+		for i, ev := range pEvents {
+			kind := ev.Context.VarKind("P")
+			require.Equal(t, VarParam, kind, "P should be VarParam")
+			_ = i // occurrence is best-effort; not asserted here
+		}
+
+		// l should be a local (from #set)
+		lEvents := counts["l"]
+		require.GreaterOrEqual(t, len(lEvents), 1)
+		for i, ev := range lEvents {
+			kind := ev.Context.VarKind("l")
+			require.Equal(t, VarLocal, kind, "l should be VarLocal")
+			_ = i
+		}
+	})
+}

--- a/est/op/func.go
+++ b/est/op/func.go
@@ -426,6 +426,38 @@ func (f *Functions) IsFuncNs(ns string) bool {
 	return ok
 }
 
+// NamespaceNames returns all registered function namespaces.
+func (f *Functions) NamespaceNames() []string {
+	names := make([]string, 0, len(f.ns))
+	for k := range f.ns {
+		names = append(names, k)
+	}
+	return names
+}
+
+// HasStandalone reports if a standalone function with the given name is registered.
+func (f *Functions) HasStandalone(name string) bool {
+	if _, ok := f.index[name]; ok {
+		return true
+	}
+	if _, ok := f.functions[name]; ok {
+		return true
+	}
+	return false
+}
+
+// StandaloneNames returns standalone function names.
+func (f *Functions) StandaloneNames() []string {
+	names := make([]string, 0, len(f.index)+len(f.functions))
+	for k := range f.index {
+		names = append(names, k)
+	}
+	for k := range f.functions {
+		names = append(names, k)
+	}
+	return names
+}
+
 func (f *Functions) Method(rType reflect.Type, id string, call *expr.Call) (*Func, error) {
 	return f.method(rType, id, call)
 }

--- a/est/state.go
+++ b/est/state.go
@@ -75,7 +75,8 @@ func (s *State) Reset() {
 
 	s.Buffer.Reset()
 	s.Errors = nil
-	s.isTaken = true
+	s.Ctx = context.Background()
+	s.isTaken = false
 }
 
 func (s *State) SetContext(ctx context.Context) { s.Ctx = ctx }

--- a/est/stmt/foreach.go
+++ b/est/stmt/foreach.go
@@ -17,6 +17,15 @@ type ForEach struct {
 	*xunsafe.Slice
 }
 
+// ForEachInfo holds loop context values exposed as $foreach in templates.
+type ForEachInfo struct {
+	Index   int
+	Count   int
+	HasNext bool
+	First   bool
+	Last    bool
+}
+
 // foreachSetter sets $foreach context into state if defined.
 func foreachSetter(state *est.State, i, l int) {
 	accessor, ok := state.StateType.ValueAccessor("foreach")
@@ -24,13 +33,7 @@ func foreachSetter(state *est.State, i, l int) {
 		return
 	}
 	// Build context
-	info := struct {
-		Index   int
-		Count   int
-		HasNext bool
-		First   bool
-		Last    bool
-	}{
+	info := ForEachInfo{
 		Index:   i,
 		Count:   i + 1,
 		HasNext: i < l-1,

--- a/est/stmt/if.go
+++ b/est/stmt/if.go
@@ -27,7 +27,8 @@ const (
 	zeroZeroPtr
 )
 
-var zeroCache sync.Map // map[reflect.Type]zeroMethodKind
+var zeroCache sync.Map  // map[reflect.Type]zeroMethodKind
+var sliceCache sync.Map // map[reflect.Type]*xunsafe.Slice
 
 func lookupZeroMethod(t reflect.Type) zeroMethodKind {
 	if v, ok := zeroCache.Load(t); ok {
@@ -50,6 +51,15 @@ func lookupZeroMethod(t reflect.Type) zeroMethodKind {
 	}
 	zeroCache.Store(t, kind)
 	return kind
+}
+
+func lookupSliceAccessor(t reflect.Type) *xunsafe.Slice {
+	if v, ok := sliceCache.Load(t); ok {
+		return v.(*xunsafe.Slice)
+	}
+	xs := xunsafe.NewSlice(t)
+	sliceCache.Store(t, xs)
+	return xs
 }
 
 func (i *If) computeWithoutElse(state *est.State) unsafe.Pointer {
@@ -131,7 +141,7 @@ func conditionOperand(condition *op2.Expression, control est.Control) (*op2.Oper
 
 	switch rType.Kind() {
 	case reflect.Slice:
-		xs := xunsafe.NewSlice(rType)
+		xs := lookupSliceAccessor(rType)
 		newOperand.Comp = func(state *est.State) unsafe.Pointer {
 			anPtr := anOperand.Exec(state)
 			if anPtr == nil {

--- a/listener.go
+++ b/listener.go
@@ -1,0 +1,35 @@
+package velty
+
+import "github.com/viant/velty/ast"
+
+// EventType represents the type of parser event.
+type EventType int
+
+const (
+	// EventEnterNode indicates entering an AST node.
+	EventEnterNode EventType = iota
+	// EventExitNode indicates exiting an AST node.
+	EventExitNode
+)
+
+// Event carries parser event data to listeners.
+type Event struct {
+	Type    EventType
+	Node    ast.Node
+	Context *ParserContext
+	// Optional span/position if available
+	Span     Span
+	Position Position
+	// ExprContext describes where this node appears (control/text/etc.).
+	ExprContext ExprContext
+	// Occurrence is a 1-based occurrence index for variable-like symbols
+	// such as selectors ($X) when applicable; otherwise 0.
+	Occurrence int
+}
+
+// ParserListener defines hooks for parser events during AST construction.
+// Implementations can perform actions when nodes are entered or exited.
+type ParserListener interface {
+	// OnEvent is invoked for each parser event with full event data.
+	OnEvent(e Event)
+}

--- a/options.go
+++ b/options.go
@@ -4,20 +4,40 @@ import (
 	"github.com/viant/velty/functions"
 )
 
-//Option represents Planner generic option
+// Option represents Planner generic option
 type Option interface{}
 
-//BufferSize represents initial size of the buffer
+// BufferSize represents initial size of the buffer
 type BufferSize int
 
-//CacheSize represents cache size in case of the dynamic template evaluation
+// CacheSize represents cache size in case of the dynamic template evaluation
 type CacheSize int
 
-//EscapeHTML escapes HTML in passed variables.
+// EscapeHTML escapes HTML in passed variables.
 type EscapeHTML bool
 
-//PanicOnError panics and recover when first error returned.
+// PanicOnError panics and recover when first error returned.
 type PanicOnError bool
 
-//TypeParser parses type string representation into reflect.Type
+// TypeParser parses type string representation into reflect.Type
 type TypeParser = functions.TypeParser
+
+// Listener registers a ParserListener to receive parse events.
+// Usage: New(Listener(yourListener))
+type Listener ParserListener
+
+// Adjuster registers a NodeAdjuster to transform AST nodes.
+// Usage: New(Adjuster(yourAdjuster))
+type Adjuster NodeAdjuster
+
+// Policies registers a PolicyRegistry to drive adjustments.
+// Usage: New(Policies(reg)) and then use reg.AsAdjuster() as Adjuster.
+type Policies *PolicyRegistry
+
+// Evaluate controls evaluate traversal.
+// EvalCfg registers evaluate traversal configuration.
+type EvalCfg EvaluateConfig
+
+// PlanHooks registers a planning listener to receive binding hooks.
+// Usage: New(PlanHooks(yourPlannerListener))
+type PlanHooks PlannerListener

--- a/parser/assign.go
+++ b/parser/assign.go
@@ -6,8 +6,8 @@ import (
 	"github.com/viant/velty/ast/stmt"
 )
 
-func matchAssign(cursor *parsly.Cursor) (*stmt.Statement, error) {
-	variable, err := matchVariable(cursor)
+func matchAssign(cursor *parsly.Cursor, spans *spanState) (*stmt.Statement, error) {
+	variable, err := matchVariable(cursor, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -23,12 +23,12 @@ func matchAssign(cursor *parsly.Cursor) (*stmt.Statement, error) {
 		return nil, fmt.Errorf("didn't found operator token for given token %v", matched.Name)
 	}
 
-	_, expression, err := matchOperand(cursor, Boolean, String, Number)
+	_, expression, err := matchOperand(cursor, spans, Boolean, String, Number)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = addEquationIfNeeded(cursor, &expression); err != nil {
+	if err = addEquationIfNeeded(cursor, spans, &expression); err != nil {
 		return nil, err
 	}
 

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -6,7 +6,7 @@ import (
 	"github.com/viant/velty/ast/expr"
 )
 
-func matchEquationExpression(cursor *parsly.Cursor) (ast2.Expression, error) {
+func matchEquationExpression(cursor *parsly.Cursor, spans *spanState) (ast2.Expression, error) {
 	candidates := []*parsly.Token{Parentheses}
 	matched := cursor.MatchAfterOptional(WhiteSpace, candidates...)
 
@@ -18,11 +18,11 @@ func matchEquationExpression(cursor *parsly.Cursor) (ast2.Expression, error) {
 		shouldNegate := matched.Code == negationToken
 
 		expressionCursor := parsly.NewCursor("", []byte(expressionValue[1:len(expressionValue)-1]), 0)
-		expression, err := matchEquationExpression(expressionCursor)
+		expression, err := matchEquationExpression(expressionCursor, spans)
 		if err != nil {
 			return nil, err
 		}
-		err = addEquationIfNeeded(cursor, &expression)
+		err = addEquationIfNeeded(cursor, spans, &expression)
 		if err != nil {
 			return nil, err
 		}
@@ -37,7 +37,7 @@ func matchEquationExpression(cursor *parsly.Cursor) (ast2.Expression, error) {
 
 		return result, nil
 	default:
-		_, expression, err := matchOperand(cursor, dataTypeMatchers...)
+		_, expression, err := matchOperand(cursor, spans, dataTypeMatchers...)
 		if err != nil {
 			return nil, err
 		}

--- a/parser/if.go
+++ b/parser/if.go
@@ -5,8 +5,8 @@ import (
 	"github.com/viant/velty/ast/stmt"
 )
 
-func matchIf(cursor *parsly.Cursor) (*stmt.If, error) {
-	expression, err := matchEquationExpression(cursor)
+func matchIf(cursor *parsly.Cursor, spans *spanState) (*stmt.If, error) {
+	expression, err := matchEquationExpression(cursor, spans)
 
 	if err != nil {
 		return nil, err

--- a/parser/operand.go
+++ b/parser/operand.go
@@ -33,6 +33,10 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		}
 
 		expr = &aexpr.Parentheses{P: expr}
+		// span covers parentheses expression including brackets
+		pStart := cursor.Pos - len(text)
+		pEnd := cursor.Pos - 1
+		recordSpan(expr, pStart, pEnd)
 
 		if hasNegation {
 			expr = &aexpr.Unary{
@@ -46,6 +50,9 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		value := matched.Text(cursor)
 		matcher = String
 		expression = aexpr.StringLiteral(value[1 : len(value)-1])
+		s := cursor.Pos - len(value)
+		e := cursor.Pos - 1
+		recordSpan(expression, s, e)
 
 	case selectorStartToken:
 		expression, err = MatchSelector(cursor)
@@ -59,11 +66,17 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		value := matched.Text(cursor)
 		matcher = Number
 		expression = aexpr.NumberLiteral(value)
+		s := cursor.Pos - len(value)
+		e := cursor.Pos - 1
+		recordSpan(expression, s, e)
 
 	case booleanToken:
 		value := matched.Text(cursor)
 		matcher = Boolean
 		expression = aexpr.BoolLiteral(value)
+		s := cursor.Pos - len(value)
+		e := cursor.Pos - 1
+		recordSpan(expression, s, e)
 
 	case quoteToken:
 		matched = cursor.MatchOne(StringFinish)
@@ -75,15 +88,24 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		if len(value) == 1 { // matched `"`
 			matcher = String
 			expression = aexpr.StringLiteral("")
+			s := cursor.Pos - len(value)
+			e := cursor.Pos - 1
+			recordSpan(expression, s, e)
 		} else {
 			newCursor := parsly.NewCursor("", []byte(value[:len(value)-1]), 0)
 
 			matcher, expression, err = matchOperand(newCursor, candidates...)
 			if err != nil {
 				expression = aexpr.StringLiteral(value[:len(value)-1])
+				s := cursor.Pos - len(value)
+				e := cursor.Pos - 1
+				recordSpan(expression, s, e)
 			} else {
 				if _, ok := expression.(*aexpr.Select); !ok {
 					expression = aexpr.StringLiteral(value[:len(value)-1])
+					s := cursor.Pos - len(value)
+					e := cursor.Pos - 1
+					recordSpan(expression, s, e)
 				}
 			}
 		}
@@ -94,6 +116,10 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		expression = &aexpr.Unary{
 			Token: ast2.NEG,
 			X:     expression,
+		}
+		// approximate span: extend one char to the left of operand
+		if s, ok := getSpan(expression.(*aexpr.Unary).X); ok {
+			recordSpan(expression, s.Start-1, s.End)
 		}
 	}
 	err = addEquationIfNeeded(cursor, &expression)
@@ -147,6 +173,20 @@ func addEquationIfNeeded(cursor *parsly.Cursor, expression *ast2.Expression) err
 			X:     *expression,
 			Token: token,
 			Y:     rightExpression,
+		}
+		// derive span from children if available
+		if lx, okx := getSpan((*expression).(*aexpr.Binary).X); okx {
+			if ry, oky := getSpan((*expression).(*aexpr.Binary).Y); oky {
+				start := lx.Start
+				if ry.Start < start {
+					start = ry.Start
+				}
+				end := lx.End
+				if ry.End > end {
+					end = ry.End
+				}
+				recordSpan(*expression, start, end)
+			}
 		}
 	}
 }

--- a/parser/operand.go
+++ b/parser/operand.go
@@ -9,7 +9,7 @@ import (
 
 var dataTypeMatchers = []*parsly.Token{String, Boolean, Number}
 
-func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.Token, ast2.Expression, error) {
+func matchOperand(cursor *parsly.Cursor, spans *spanState, candidates ...*parsly.Token) (*parsly.Token, ast2.Expression, error) {
 	matched := cursor.MatchAfterOptional(WhiteSpace, Negation)
 	hasNegation := matched.Code == negationToken
 
@@ -27,7 +27,7 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 	case parenthesesToken:
 		text := matched.Text(cursor)
 		newCursor := parsly.NewCursor("", []byte(text[1:len(text)-1]), 0)
-		token, expr, err := matchOperand(newCursor, candidates...)
+		token, expr, err := matchOperand(newCursor, spans, candidates...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -36,7 +36,7 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		// span covers parentheses expression including brackets
 		pStart := cursor.Pos - len(text)
 		pEnd := cursor.Pos - 1
-		recordSpan(expr, pStart, pEnd)
+		spans.recordSpan(expr, pStart, pEnd)
 
 		if hasNegation {
 			expr = &aexpr.Unary{
@@ -52,10 +52,10 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		expression = aexpr.StringLiteral(value[1 : len(value)-1])
 		s := cursor.Pos - len(value)
 		e := cursor.Pos - 1
-		recordSpan(expression, s, e)
+		spans.recordSpan(expression, s, e)
 
 	case selectorStartToken:
-		expression, err = MatchSelector(cursor)
+		expression, err = MatchSelector(cursor, spans)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -68,7 +68,7 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		expression = aexpr.NumberLiteral(value)
 		s := cursor.Pos - len(value)
 		e := cursor.Pos - 1
-		recordSpan(expression, s, e)
+		spans.recordSpan(expression, s, e)
 
 	case booleanToken:
 		value := matched.Text(cursor)
@@ -76,7 +76,7 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 		expression = aexpr.BoolLiteral(value)
 		s := cursor.Pos - len(value)
 		e := cursor.Pos - 1
-		recordSpan(expression, s, e)
+		spans.recordSpan(expression, s, e)
 
 	case quoteToken:
 		matched = cursor.MatchOne(StringFinish)
@@ -90,22 +90,22 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 			expression = aexpr.StringLiteral("")
 			s := cursor.Pos - len(value)
 			e := cursor.Pos - 1
-			recordSpan(expression, s, e)
+			spans.recordSpan(expression, s, e)
 		} else {
 			newCursor := parsly.NewCursor("", []byte(value[:len(value)-1]), 0)
 
-			matcher, expression, err = matchOperand(newCursor, candidates...)
+			matcher, expression, err = matchOperand(newCursor, spans, candidates...)
 			if err != nil {
 				expression = aexpr.StringLiteral(value[:len(value)-1])
 				s := cursor.Pos - len(value)
 				e := cursor.Pos - 1
-				recordSpan(expression, s, e)
+				spans.recordSpan(expression, s, e)
 			} else {
 				if _, ok := expression.(*aexpr.Select); !ok {
 					expression = aexpr.StringLiteral(value[:len(value)-1])
 					s := cursor.Pos - len(value)
 					e := cursor.Pos - 1
-					recordSpan(expression, s, e)
+					spans.recordSpan(expression, s, e)
 				}
 			}
 		}
@@ -118,11 +118,11 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 			X:     expression,
 		}
 		// approximate span: extend one char to the left of operand
-		if s, ok := getSpan(expression.(*aexpr.Unary).X); ok {
-			recordSpan(expression, s.Start-1, s.End)
+		if s, ok := spans.getSpan(expression.(*aexpr.Unary).X); ok {
+			spans.recordSpan(expression, s.Start-1, s.End)
 		}
 	}
-	err = addEquationIfNeeded(cursor, &expression)
+	err = addEquationIfNeeded(cursor, spans, &expression)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +130,7 @@ func matchOperand(cursor *parsly.Cursor, candidates ...*parsly.Token) (*parsly.T
 	return matcher, expression, nil
 }
 
-func addEquationIfNeeded(cursor *parsly.Cursor, expression *ast2.Expression) error {
+func addEquationIfNeeded(cursor *parsly.Cursor, spans *spanState, expression *ast2.Expression) error {
 	for {
 		candidates := []*parsly.Token{Add, Sub, Multiply, Quo, NotEqual, Negation, Equal, And, Or, GreaterEqual, Greater, LessEqual, Less, Assign}
 		matched := cursor.MatchAfterOptional(WhiteSpace, candidates...)
@@ -149,10 +149,10 @@ func addEquationIfNeeded(cursor *parsly.Cursor, expression *ast2.Expression) err
 
 		var rightExpression ast2.Expression
 		if err == nil {
-			rightExpression, err = matchEquationExpression(eprCursor)
+			rightExpression, err = matchEquationExpression(eprCursor, spans)
 			rightExpression = &aexpr.Parentheses{P: rightExpression}
 		} else {
-			_, rightExpression, err = matchOperand(cursor, dataTypeMatchers...)
+			_, rightExpression, err = matchOperand(cursor, spans, dataTypeMatchers...)
 		}
 
 		if err != nil {
@@ -175,8 +175,8 @@ func addEquationIfNeeded(cursor *parsly.Cursor, expression *ast2.Expression) err
 			Y:     rightExpression,
 		}
 		// derive span from children if available
-		if lx, okx := getSpan((*expression).(*aexpr.Binary).X); okx {
-			if ry, oky := getSpan((*expression).(*aexpr.Binary).Y); oky {
+		if lx, okx := spans.getSpan((*expression).(*aexpr.Binary).X); okx {
+			if ry, oky := spans.getSpan((*expression).(*aexpr.Binary).Y); oky {
 				start := lx.Start
 				if ry.Start < start {
 					start = ry.Start
@@ -185,7 +185,7 @@ func addEquationIfNeeded(cursor *parsly.Cursor, expression *ast2.Expression) err
 				if ry.End > end {
 					end = ry.End
 				}
-				recordSpan(*expression, start, end)
+				spans.recordSpan(*expression, start, end)
 			}
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,9 +9,18 @@ import (
 	"strings"
 )
 
-func Parse(input []byte) (*stmt.Block, error) {
+// parse is the internal implementation shared by Parse and ParseWithSpans.
+func parse(input []byte) (*stmt.Block, error) {
 	if len(input) == 0 {
 		return &stmt.Block{}, nil
+	}
+
+	if recordSpans {
+		// initialize span registry for this parse
+		resetSpans()
+	} else {
+		// ensure no stale spans are exposed when not recording
+		nodeSpans = nil
 	}
 
 	builder := NewBuilder()
@@ -81,6 +90,18 @@ outer:
 	}
 
 	return builder.Block(), nil
+}
+
+// Parse parses the input template without recording spans (fast path).
+func Parse(input []byte) (*stmt.Block, error) {
+	recordSpans = false
+	return parse(input)
+}
+
+// ParseWithSpans parses the input template and records node spans.
+func ParseWithSpans(input []byte) (*stmt.Block, error) {
+	recordSpans = true
+	return parse(input)
 }
 
 func checkIfEscaped(cursor *parsly.Cursor) (*stmt.Append, bool) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,18 +9,10 @@ import (
 	"strings"
 )
 
-// parse is the internal implementation shared by Parse and ParseWithSpans.
-func parse(input []byte) (*stmt.Block, error) {
+// parse is the internal implementation shared by Parse and ParseWithSpans*.
+func parse(input []byte, spans *spanState) (*stmt.Block, error) {
 	if len(input) == 0 {
 		return &stmt.Block{}, nil
-	}
-
-	if recordSpans {
-		// initialize span registry for this parse
-		resetSpans()
-	} else {
-		// ensure no stale spans are exposed when not recording
-		nodeSpans = nil
 	}
 
 	builder := NewBuilder()
@@ -51,7 +43,7 @@ outer:
 		lastPosition := cursor.Pos - 1
 		switch cursor.Input[cursor.Pos-1] {
 		case '$':
-			statement, err := MatchSelector(cursor)
+			statement, err := MatchSelector(cursor, spans)
 			if err != nil {
 				rawValue := cursor.Input[lastPosition:cursor.Pos]
 				if errr := builder.PushStatement(appendToken, stmt.NewAppend(string(rawValue))); errr != nil {
@@ -70,7 +62,7 @@ outer:
 				continue
 			}
 
-			statement, match, err := matchStatement(cursor)
+			statement, match, err := matchStatement(cursor, spans)
 			if err != nil {
 				rawValue := cursor.Input[lastPosition:cursor.Pos]
 				if errr := builder.PushStatement(appendToken, stmt.NewAppend(string(rawValue))); errr != nil {
@@ -94,14 +86,23 @@ outer:
 
 // Parse parses the input template without recording spans (fast path).
 func Parse(input []byte) (*stmt.Block, error) {
-	recordSpans = false
-	return parse(input)
+	return parse(input, nil)
 }
 
 // ParseWithSpans parses the input template and records node spans.
 func ParseWithSpans(input []byte) (*stmt.Block, error) {
-	recordSpans = true
-	return parse(input)
+	root, _, err := ParseWithSpansDetailed(input)
+	return root, err
+}
+
+// ParseWithSpansDetailed parses the input template and returns node spans.
+func ParseWithSpansDetailed(input []byte) (*stmt.Block, map[ast.Node]NodeSpan, error) {
+	spans := newSpanState(true)
+	root, err := parse(input, spans)
+	if err != nil {
+		return nil, nil, err
+	}
+	return root, spans.Spans(), nil
 }
 
 func checkIfEscaped(cursor *parsly.Cursor) (*stmt.Append, bool) {
@@ -137,12 +138,12 @@ func appendStatementIfNeeded(text string, stack *Builder) error {
 	return nil
 }
 
-func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
+func matchStatement(cursor *parsly.Cursor, spans *spanState) (ast.Statement, int, error) {
 	matched := cursor.MatchAfterOptional(WhiteSpace, Brackets)
 	if matched.Token.Code == bracketsToken {
 		stmt := matched.Text(cursor)
 		newCursor := parsly.NewCursor("", []byte(stmt[1:len(stmt)-1]), 0)
-		return matchStatement(newCursor)
+		return matchStatement(newCursor, spans)
 	}
 
 	candidates := []*parsly.Token{If, ElseIf, Else, Set, ForEach, For, Evaluate, End}
@@ -158,7 +159,7 @@ func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
 			return nil, 0, err
 		}
 
-		ifStmt, err := matchIf(expressionCursor)
+		ifStmt, err := matchIf(expressionCursor, spans)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -179,7 +180,7 @@ func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
 			return nil, 0, err
 		}
 
-		assignStmt, err := matchAssign(expressionCursor)
+		assignStmt, err := matchAssign(expressionCursor, spans)
 		if err != nil {
 			return nil, expressionCode, err
 		}
@@ -191,7 +192,7 @@ func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
 			return nil, 0, err
 		}
 
-		forEachStmt, err := matchForEach(expressionCursor)
+		forEachStmt, err := matchForEach(expressionCursor, spans)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -204,7 +205,7 @@ func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
 			return nil, 0, err
 		}
 
-		forStmt, err := matchFor(expressionCursor)
+		forStmt, err := matchFor(expressionCursor, spans)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -216,7 +217,7 @@ func matchStatement(cursor *parsly.Cursor) (ast.Statement, int, error) {
 		if err != nil {
 			return nil, 0, err
 		}
-		_, operand, err := matchOperand(evaluateCursor, String)
+		_, operand, err := matchOperand(evaluateCursor, spans, String)
 
 		if err != nil {
 			return nil, 0, err

--- a/parser/range.go
+++ b/parser/range.go
@@ -7,8 +7,8 @@ import (
 	"github.com/viant/velty/ast/stmt"
 )
 
-func matchForEach(cursor *parsly.Cursor) (*stmt.ForEach, error) {
-	variable, err := matchVariable(cursor)
+func matchForEach(cursor *parsly.Cursor, spans *spanState) (*stmt.ForEach, error) {
+	variable, err := matchVariable(cursor, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func matchForEach(cursor *parsly.Cursor) (*stmt.ForEach, error) {
 
 	var index *expr.Select
 	if matched.Code == comaToken {
-		index, err = matchVariable(cursor)
+		index, err = matchVariable(cursor, spans)
 		if err != nil {
 			return nil, err
 		}
@@ -29,7 +29,7 @@ func matchForEach(cursor *parsly.Cursor) (*stmt.ForEach, error) {
 		return nil, cursor.NewError(candidates...)
 	}
 
-	dataSet, err := matchRangeable(cursor)
+	dataSet, err := matchRangeable(cursor, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -42,21 +42,21 @@ func matchForEach(cursor *parsly.Cursor) (*stmt.ForEach, error) {
 	}, nil
 }
 
-func matchFor(cursor *parsly.Cursor) (*stmt.ForLoop, error) {
+func matchFor(cursor *parsly.Cursor, spans *spanState) (*stmt.ForLoop, error) {
 	initCursor := extractForSegment(cursor)
-	forInit, err := matchAssign(initCursor)
+	forInit, err := matchAssign(initCursor, spans)
 	if err != nil {
 		return nil, err
 	}
 
 	conditionCursor := extractForSegment(cursor)
-	forCondition, err := matchEquationExpression(conditionCursor)
+	forCondition, err := matchEquationExpression(conditionCursor, spans)
 	if err != nil {
 		return nil, err
 	}
 
 	forPostCursor := extractForSegment(cursor)
-	forPost, err := matchForPost(forPostCursor)
+	forPost, err := matchForPost(forPostCursor, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +68,8 @@ func matchFor(cursor *parsly.Cursor) (*stmt.ForLoop, error) {
 	}, nil
 }
 
-func matchForPost(cursor *parsly.Cursor) (ast2.Statement, error) {
-	variable, err := matchVariable(cursor)
+func matchForPost(cursor *parsly.Cursor, spans *spanState) (ast2.Statement, error) {
+	variable, err := matchVariable(cursor, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func matchForPost(cursor *parsly.Cursor) (ast2.Statement, error) {
 	}
 
 	token := matchToken(matched)
-	_, rightOperand, err := matchOperand(cursor)
+	_, rightOperand, err := matchOperand(cursor, spans)
 	if err != nil {
 		return nil, err
 	}

--- a/parser/select.go
+++ b/parser/select.go
@@ -28,8 +28,14 @@ func matchRangeable(cursor *parsly.Cursor) (ast.Expression, error) {
 	case squareBracketsToken:
 		text := matched.Text(cursor)
 		rangeCursor := parsly.NewCursor("", []byte(text[1:len(text)-1]), 0)
-
-		return matchRange(rangeCursor)
+		expr, err := matchRange(rangeCursor)
+		if err != nil {
+			return nil, err
+		}
+		start := cursor.Pos - len(text)
+		end := cursor.Pos - 1
+		recordSpan(expr, start, end)
+		return expr, nil
 	}
 	return nil, cursor.NewError(candidates...)
 }
@@ -74,6 +80,10 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 		}
 
 		result.FullName = "$" + ID
+		// span covers full selector including leading '$'
+		start := selectorStart - 1
+		end := cursor.Pos - 1
+		recordSpan(result, start, end)
 		return result, err
 
 	}
@@ -99,6 +109,10 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 		}
 
 		selector.FullName = "$" + string(cursor.Input[selectorStart:cursor.Pos])
+		// span covers full selector including leading '$'
+		start := selectorStart - 1
+		end := cursor.Pos - 1
+		recordSpan(selector, start, end)
 		return selector, nil
 	}
 
@@ -113,6 +127,9 @@ func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
 		return MatchSelector(cursor)
 	case parenthesesToken:
 		id := matched.Text(cursor)
+		// id includes surrounding parentheses; compute start/end for call
+		callStart := cursor.Pos - len(id)
+		callEnd := cursor.Pos - 1
 		newCursor := parsly.NewCursor("", []byte(id[1:len(id)-1]), 0)
 		call, err := matchFunctionCall(newCursor)
 		if err != nil {
@@ -123,10 +140,14 @@ func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
 		if err != nil {
 			return nil, err
 		}
+		recordSpan(call, callStart, callEnd)
 		return call, nil
 
 	case squareBracketsToken:
 		id := matched.Text(cursor)
+		// id includes surrounding [..]; compute start/end for index
+		idxStart := cursor.Pos - len(id)
+		idxEnd := cursor.Pos - 1
 		newCursor := parsly.NewCursor("", []byte(id[1:len(id)-1]), 0)
 		_, expression, err := matchOperand(newCursor, Number)
 		if err != nil {
@@ -141,6 +162,7 @@ func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
 			return nil, err
 		}
 
+		recordSpan(index, idxStart, idxEnd)
 		return index, nil
 	}
 

--- a/parser/select.go
+++ b/parser/select.go
@@ -9,22 +9,22 @@ import (
 	"strings"
 )
 
-func matchVariable(cursor *parsly.Cursor) (*expr.Select, error) {
+func matchVariable(cursor *parsly.Cursor, spans *spanState) (*expr.Select, error) {
 	candidates := []*parsly.Token{SelectorStart}
 	matched := cursor.MatchAfterOptional(WhiteSpace, candidates...)
 	switch matched.Code {
 	case selectorStartToken:
-		return parseIdentity(cursor)
+		return parseIdentity(cursor, spans)
 	}
 	return nil, cursor.NewError(candidates...)
 }
 
-func matchRangeable(cursor *parsly.Cursor) (ast.Expression, error) {
+func matchRangeable(cursor *parsly.Cursor, spans *spanState) (ast.Expression, error) {
 	candidates := []*parsly.Token{SelectorStart, SquareBrackets}
 	matched := cursor.MatchAfterOptional(WhiteSpace, candidates...)
 	switch matched.Code {
 	case selectorStartToken:
-		return MatchSelector(cursor)
+		return MatchSelector(cursor, spans)
 	case squareBracketsToken:
 		text := matched.Text(cursor)
 		rangeCursor := parsly.NewCursor("", []byte(text[1:len(text)-1]), 0)
@@ -34,7 +34,7 @@ func matchRangeable(cursor *parsly.Cursor) (ast.Expression, error) {
 		}
 		start := cursor.Pos - len(text)
 		end := cursor.Pos - 1
-		recordSpan(expr, start, end)
+		spans.recordSpan(expr, start, end)
 		return expr, nil
 	}
 	return nil, cursor.NewError(candidates...)
@@ -62,7 +62,11 @@ func matchRange(cursor *parsly.Cursor) (ast.Expression, error) {
 	}, nil
 }
 
-func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
+func MatchSelector(cursor *parsly.Cursor, opts ...*spanState) (*expr.Select, error) {
+	var spans *spanState
+	if len(opts) > 0 {
+		spans = opts[0]
+	}
 	selectorStart := cursor.Pos
 	matched := cursor.MatchOne(Negation) // Java velocity supports `$!`. If String is null, then it will be replaced with Empty String. In Go - we don't need that
 	matched = cursor.MatchOne(SelectorBlock)
@@ -70,7 +74,7 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 	if matched.Code == selectorBlockToken {
 		ID := matched.Text(cursor)
 		selectorCursor := parsly.NewCursor("", []byte(ID[1:len(ID)-1]), 0)
-		result, err := MatchSelector(selectorCursor)
+		result, err := MatchSelector(selectorCursor, spans)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +87,7 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 		// span covers full selector including leading '$'
 		start := selectorStart - 1
 		end := cursor.Pos - 1
-		recordSpan(result, start, end)
+		spans.recordSpan(result, start, end)
 		return result, err
 
 	}
@@ -98,12 +102,12 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 	case selectorToken:
 		selectorValue := matched.Text(cursor)
 		selectorCursor := parsly.NewCursor("", []byte(selectorValue), 0)
-		selector, err := parseIdentity(selectorCursor)
+		selector, err := parseIdentity(selectorCursor, spans)
 		if err != nil {
 			return nil, err
 		}
 
-		selector.X, err = matchCall(cursor)
+		selector.X, err = matchCall(cursor, spans)
 		if err != nil {
 			return nil, err
 		}
@@ -112,35 +116,35 @@ func MatchSelector(cursor *parsly.Cursor) (*expr.Select, error) {
 		// span covers full selector including leading '$'
 		start := selectorStart - 1
 		end := cursor.Pos - 1
-		recordSpan(selector, start, end)
+		spans.recordSpan(selector, start, end)
 		return selector, nil
 	}
 
 	return nil, cursor.NewError(candidates...)
 }
 
-func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
+func matchCall(cursor *parsly.Cursor, spans *spanState) (ast.Expression, error) {
 	candidates := []*parsly.Token{Parentheses, Dot, SquareBrackets}
 	matched := cursor.MatchAny(candidates...)
 	switch matched.Code {
 	case dotToken:
-		return MatchSelector(cursor)
+		return MatchSelector(cursor, spans)
 	case parenthesesToken:
 		id := matched.Text(cursor)
 		// id includes surrounding parentheses; compute start/end for call
 		callStart := cursor.Pos - len(id)
 		callEnd := cursor.Pos - 1
 		newCursor := parsly.NewCursor("", []byte(id[1:len(id)-1]), 0)
-		call, err := matchFunctionCall(newCursor)
+		call, err := matchFunctionCall(newCursor, spans)
 		if err != nil {
 			return nil, err
 		}
 
-		call.X, err = matchCall(cursor)
+		call.X, err = matchCall(cursor, spans)
 		if err != nil {
 			return nil, err
 		}
-		recordSpan(call, callStart, callEnd)
+		spans.recordSpan(call, callStart, callEnd)
 		return call, nil
 
 	case squareBracketsToken:
@@ -149,7 +153,7 @@ func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
 		idxStart := cursor.Pos - len(id)
 		idxEnd := cursor.Pos - 1
 		newCursor := parsly.NewCursor("", []byte(id[1:len(id)-1]), 0)
-		_, expression, err := matchOperand(newCursor, Number)
+		_, expression, err := matchOperand(newCursor, spans, Number)
 		if err != nil {
 			return nil, err
 		}
@@ -157,19 +161,19 @@ func matchCall(cursor *parsly.Cursor) (ast.Expression, error) {
 		index := &expr.SliceIndex{
 			X: expression,
 		}
-		index.Y, err = matchCall(cursor)
+		index.Y, err = matchCall(cursor, spans)
 		if err != nil {
 			return nil, err
 		}
 
-		recordSpan(index, idxStart, idxEnd)
+		spans.recordSpan(index, idxStart, idxEnd)
 		return index, nil
 	}
 
 	return nil, nil
 }
 
-func parseIdentity(cursor *parsly.Cursor) (*expr.Select, error) {
+func parseIdentity(cursor *parsly.Cursor, spans *spanState) (*expr.Select, error) {
 	candidates := []*parsly.Token{Selector, SelectorBlock}
 	matched := cursor.MatchAny(candidates...)
 	selectorId := matched.Text(cursor)
@@ -180,11 +184,11 @@ func parseIdentity(cursor *parsly.Cursor) (*expr.Select, error) {
 		return &expr.Select{ID: selectorId}, nil
 	case selectorBlockToken:
 		newCursor := parsly.NewCursor("", []byte(selectorId[1:len(selectorId)-1]), 0)
-		return parseIdentity(newCursor)
+		return parseIdentity(newCursor, spans)
 	case selectorToken:
 		selector := &expr.Select{ID: selectorId}
 		var err error
-		selector.X, err = matchCall(cursor)
+		selector.X, err = matchCall(cursor, spans)
 		if err != nil {
 			return nil, err
 		}
@@ -193,12 +197,12 @@ func parseIdentity(cursor *parsly.Cursor) (*expr.Select, error) {
 	return nil, cursor.NewError(candidates...)
 }
 
-func matchFunctionCall(cursor *parsly.Cursor) (*expr.Call, error) {
+func matchFunctionCall(cursor *parsly.Cursor, spans *spanState) (*expr.Call, error) {
 	expressions := make([]ast.Expression, 0)
 
 	for cursor.Pos < cursor.InputSize-1 {
 		argumentCursor := extractArgument(cursor)
-		_, expression, err := matchOperand(argumentCursor, String, Boolean, Number)
+		_, expression, err := matchOperand(argumentCursor, spans, String, Boolean, Number)
 		if err != nil {
 			return nil, err
 		}

--- a/parser/spans.go
+++ b/parser/spans.go
@@ -1,0 +1,51 @@
+package parser
+
+import (
+	"github.com/viant/velty/ast"
+)
+
+// NodeSpan represents a byte range [Start, End] in the parsed source.
+type NodeSpan struct {
+	Start int
+	End   int
+}
+
+// nodeSpans holds spans for the most recent parse when span recording is enabled.
+var nodeSpans map[ast.Node]NodeSpan
+
+// recordSpans controls whether spans are recorded for the current parse.
+var recordSpans bool
+
+// resetSpans initializes the global span registry for a new parse when recording is enabled.
+func resetSpans() {
+	if !recordSpans {
+		nodeSpans = nil
+		return
+	}
+	nodeSpans = make(map[ast.Node]NodeSpan)
+}
+
+// recordSpan registers a span for the given node when recording is enabled.
+func recordSpan(n ast.Node, start, end int) {
+	if !recordSpans || n == nil {
+		return
+	}
+	if nodeSpans == nil {
+		nodeSpans = make(map[ast.Node]NodeSpan)
+	}
+	nodeSpans[n] = NodeSpan{Start: start, End: end}
+}
+
+// getSpan returns a span for a node if recorded.
+func getSpan(n ast.Node) (NodeSpan, bool) {
+	if nodeSpans == nil {
+		return NodeSpan{}, false
+	}
+	s, ok := nodeSpans[n]
+	return s, ok
+}
+
+// Spans exposes the current parse node spans.
+func Spans() map[ast.Node]NodeSpan {
+	return nodeSpans
+}

--- a/parser/spans.go
+++ b/parser/spans.go
@@ -10,42 +10,43 @@ type NodeSpan struct {
 	End   int
 }
 
-// nodeSpans holds spans for the most recent parse when span recording is enabled.
-var nodeSpans map[ast.Node]NodeSpan
+type spanState struct {
+	record bool
+	spans  map[ast.Node]NodeSpan
+}
 
-// recordSpans controls whether spans are recorded for the current parse.
-var recordSpans bool
-
-// resetSpans initializes the global span registry for a new parse when recording is enabled.
-func resetSpans() {
-	if !recordSpans {
-		nodeSpans = nil
-		return
+func newSpanState(record bool) *spanState {
+	st := &spanState{record: record}
+	if record {
+		st.spans = make(map[ast.Node]NodeSpan)
 	}
-	nodeSpans = make(map[ast.Node]NodeSpan)
+	return st
 }
 
 // recordSpan registers a span for the given node when recording is enabled.
-func recordSpan(n ast.Node, start, end int) {
-	if !recordSpans || n == nil {
+func (s *spanState) recordSpan(n ast.Node, start, end int) {
+	if s == nil || !s.record || n == nil {
 		return
 	}
-	if nodeSpans == nil {
-		nodeSpans = make(map[ast.Node]NodeSpan)
+	if s.spans == nil {
+		s.spans = make(map[ast.Node]NodeSpan)
 	}
-	nodeSpans[n] = NodeSpan{Start: start, End: end}
+	s.spans[n] = NodeSpan{Start: start, End: end}
 }
 
 // getSpan returns a span for a node if recorded.
-func getSpan(n ast.Node) (NodeSpan, bool) {
-	if nodeSpans == nil {
+func (s *spanState) getSpan(n ast.Node) (NodeSpan, bool) {
+	if s == nil || s.spans == nil {
 		return NodeSpan{}, false
 	}
-	s, ok := nodeSpans[n]
-	return s, ok
+	span, ok := s.spans[n]
+	return span, ok
 }
 
-// Spans exposes the current parse node spans.
-func Spans() map[ast.Node]NodeSpan {
-	return nodeSpans
+// Spans exposes parse node spans for this parse invocation.
+func (s *spanState) Spans() map[ast.Node]NodeSpan {
+	if s == nil || s.spans == nil {
+		return nil
+	}
+	return s.spans
 }

--- a/parser_context.go
+++ b/parser_context.go
@@ -1,0 +1,405 @@
+package velty
+
+import (
+	"github.com/viant/velty/ast"
+)
+
+// Span represents byte offsets for a node within a source template.
+type Span struct {
+	Start int
+	End   int
+}
+
+// Position holds line/column coordinates for a span.
+type Position struct {
+	Line    int
+	Col     int
+	EndLine int
+	EndCol  int
+}
+
+// ExprContextKind classifies where an expression/node appears in the template.
+type ExprContextKind uint8
+
+const (
+	CtxUnknown ExprContextKind = iota
+	// Control flow
+	CtxIfCond
+	CtxIfBody
+	CtxElseIfCond
+	CtxElseBody
+	CtxForEachCond
+	CtxForEachBody
+	CtxForLoopInit
+	CtxForLoopCond
+	CtxForLoopPost
+	// Assignment
+	CtxSetLHS
+	CtxSetRHS
+	// Expression vs text
+	CtxAppendExpr
+	CtxPlainText
+	// Function arguments
+	CtxFuncArg
+	// Evaluate expression
+	CtxEvaluate
+)
+
+// ExprContext describes the current expression context for a node.
+type ExprContext struct {
+	Kind   ExprContextKind
+	ArgIdx int16 // for CtxFuncArg, -1 otherwise
+}
+
+// VarKind classifies a symbol within the current parser context.
+type VarKind uint8
+
+const (
+	VarUnknown VarKind = iota
+	VarLocal
+	VarParam
+	VarConst
+	VarNamespace
+	VarFunc
+)
+
+// Scope represents a lexical scope with variables and an optional parent scope.
+type Scope struct {
+	Parent *Scope
+	Vars   map[string]interface{}
+}
+
+// NewScope creates a new Scope with the given parent.
+func NewScope(parent *Scope) *Scope {
+	return &Scope{
+		Parent: parent,
+		Vars:   make(map[string]interface{}),
+	}
+}
+
+// ParserContext holds parser state, including scope stack and node ancestry.
+type ParserContext struct {
+	// Current variable scope
+	Scope *Scope
+	// Symbol sets for resolution helpers
+	locals     map[string]struct{}
+	params     map[string]struct{}
+	namespaces map[string]struct{}
+	funcs      map[string]struct{}
+	consts     map[string]struct{}
+	decorators map[string]struct{}
+	// occ keeps per-name occurrence counters for selectors/variables.
+	occ map[string]int
+	// NodeStack tracks ancestor nodes
+	NodeStack []ast.Node
+	// exprCtxStack tracks expression/statement context
+	exprCtxStack []ExprContext
+	// Source and position mapping (optional)
+	File       string
+	Source     []byte
+	lineStarts []int
+	// Node span registry
+	nodeSpans map[ast.Node]Span
+	patches   []Patch
+	Reporter  *Reporter
+	// Evaluate handling configuration
+	EvalConfig EvaluateConfig
+	EvalDepth  int
+}
+
+// CurrentExprContext returns the innermost expression context, if any.
+func (p *ParserContext) CurrentExprContext() ExprContext {
+	if len(p.exprCtxStack) == 0 {
+		return ExprContext{Kind: CtxUnknown, ArgIdx: -1}
+	}
+	return p.exprCtxStack[len(p.exprCtxStack)-1]
+}
+
+// PushExprContext adds a new expression context on the stack.
+func (p *ParserContext) PushExprContext(ctx ExprContext) {
+	p.exprCtxStack = append(p.exprCtxStack, ctx)
+}
+
+// PopExprContext removes the most recent expression context.
+func (p *ParserContext) PopExprContext() {
+	if len(p.exprCtxStack) == 0 {
+		return
+	}
+	p.exprCtxStack = p.exprCtxStack[:len(p.exprCtxStack)-1]
+}
+
+// EnterScope pushes a new nested scope on the context.
+func (p *ParserContext) EnterScope() {
+	p.Scope = NewScope(p.Scope)
+}
+
+// ExitScope pops the current scope, reverting to the parent.
+func (p *ParserContext) ExitScope() {
+	if p.Scope != nil {
+		p.Scope = p.Scope.Parent
+	}
+}
+
+// SeedSymbols initializes known params, namespaces, functions, and consts.
+func (p *ParserContext) SeedSymbols(params, namespaces, funcs, consts []string) {
+	if p.params == nil {
+		p.params = map[string]struct{}{}
+	}
+	if p.namespaces == nil {
+		p.namespaces = map[string]struct{}{}
+	}
+	if p.funcs == nil {
+		p.funcs = map[string]struct{}{}
+	}
+	if p.consts == nil {
+		p.consts = map[string]struct{}{}
+	}
+	for _, s := range params {
+		p.params[s] = struct{}{}
+	}
+	for _, s := range namespaces {
+		p.namespaces[s] = struct{}{}
+	}
+	for _, s := range funcs {
+		p.funcs[s] = struct{}{}
+	}
+	for _, s := range consts {
+		p.consts[s] = struct{}{}
+	}
+}
+
+// MarkLocal records a local variable in the current scope and set.
+func (p *ParserContext) MarkLocal(name string) {
+	if p.locals == nil {
+		p.locals = map[string]struct{}{}
+	}
+	p.locals[name] = struct{}{}
+	if p.Scope != nil {
+		if p.Scope.Vars == nil {
+			p.Scope.Vars = map[string]interface{}{}
+		}
+		p.Scope.Vars[name] = true
+	}
+}
+
+// MarkUnexpandRaw marks a name as having UnexpandRaw decorator.
+func (p *ParserContext) MarkUnexpandRaw(name string) {
+	if p.decorators == nil {
+		p.decorators = map[string]struct{}{}
+	}
+	p.decorators[name] = struct{}{}
+}
+
+// IsLocal reports if a symbol is a local variable.
+func (p *ParserContext) IsLocal(name string) bool {
+	if p.locals != nil {
+		if _, ok := p.locals[name]; ok {
+			return true
+		}
+	}
+	for s := p.Scope; s != nil; s = s.Parent {
+		if s.Vars != nil {
+			if _, ok := s.Vars[name]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsParam reports if a symbol is a planner-defined param (root variable).
+func (p *ParserContext) IsParam(name string) bool {
+	if p.params == nil {
+		return false
+	}
+	_, ok := p.params[name]
+	return ok
+}
+
+// IsNamespace reports if a name is a function namespace.
+func (p *ParserContext) IsNamespace(name string) bool {
+	if p.namespaces == nil {
+		return false
+	}
+	_, ok := p.namespaces[name]
+	return ok
+}
+
+// IsStandaloneFunc reports if a name is a registered standalone function.
+func (p *ParserContext) IsStandaloneFunc(name string) bool {
+	if p.funcs == nil {
+		return false
+	}
+	_, ok := p.funcs[name]
+	return ok
+}
+
+// IsConst reports if a symbol is a known constant.
+func (p *ParserContext) IsConst(name string) bool {
+	if p.consts == nil {
+		return false
+	}
+	_, ok := p.consts[name]
+	return ok
+}
+
+// HasUnexpandRaw reports if a name is marked with UnexpandRaw decorator.
+func (p *ParserContext) HasUnexpandRaw(name string) bool {
+	if p.decorators == nil {
+		return false
+	}
+	_, ok := p.decorators[name]
+	return ok
+}
+
+// VarKind reports the classification of a symbol within this context.
+func (p *ParserContext) VarKind(name string) VarKind {
+	if name == "" {
+		return VarUnknown
+	}
+	if p.IsLocal(name) {
+		return VarLocal
+	}
+	if p.IsParam(name) {
+		return VarParam
+	}
+	if p.IsConst(name) {
+		return VarConst
+	}
+	if p.IsNamespace(name) {
+		return VarNamespace
+	}
+	if p.IsStandaloneFunc(name) {
+		return VarFunc
+	}
+	return VarUnknown
+}
+
+// BumpOccurrence increments and returns the 1-based occurrence index for name.
+func (p *ParserContext) BumpOccurrence(name string) int {
+	if name == "" {
+		return 0
+	}
+	if p.occ == nil {
+		p.occ = make(map[string]int)
+	}
+	next := p.occ[name] + 1
+	p.occ[name] = next
+	return next
+}
+
+// PushNode records a node entry into the context stack.
+func (p *ParserContext) PushNode(node ast.Node) {
+	p.NodeStack = append(p.NodeStack, node)
+}
+
+// PopNode removes the most recent node from the context stack.
+func (p *ParserContext) PopNode() {
+	if len(p.NodeStack) > 0 {
+		p.NodeStack = p.NodeStack[:len(p.NodeStack)-1]
+	}
+}
+
+// CurrentNode returns the most recently pushed node or nil if empty.
+func (p *ParserContext) CurrentNode() ast.Node {
+	if len(p.NodeStack) == 0 {
+		return nil
+	}
+	return p.NodeStack[len(p.NodeStack)-1]
+}
+
+// InitSource initializes source bytes and precomputes line starts.
+func (p *ParserContext) InitSource(file string, src []byte) {
+	p.File = file
+	p.Source = src
+	p.lineStarts = make([]int, 0, 128)
+	p.lineStarts = append(p.lineStarts, 0)
+	for i, b := range src {
+		if b == '\n' {
+			p.lineStarts = append(p.lineStarts, i+1)
+		}
+	}
+	if p.nodeSpans == nil {
+		p.nodeSpans = make(map[ast.Node]Span)
+	}
+}
+
+// SetSpan registers a span for a node.
+func (p *ParserContext) SetSpan(n ast.Node, s Span) {
+	if p.nodeSpans == nil {
+		p.nodeSpans = make(map[ast.Node]Span)
+	}
+	p.nodeSpans[n] = s
+}
+
+// GetSpan retrieves a span for a node, if any.
+func (p *ParserContext) GetSpan(n ast.Node) (Span, bool) {
+	if p.nodeSpans == nil {
+		return Span{}, false
+	}
+	s, ok := p.nodeSpans[n]
+	return s, ok
+}
+
+// ResolvePosition converts a span to line/column positions.
+func (p *ParserContext) ResolvePosition(s Span) Position {
+	pos := Position{}
+	if p.lineStarts == nil || len(p.lineStarts) == 0 || s.Start < 0 || s.End < 0 {
+		return pos
+	}
+	// find start line
+	pos.Line, pos.Col = p.byteToLineCol(s.Start)
+	pos.EndLine, pos.EndCol = p.byteToLineCol(s.End)
+	return pos
+}
+
+func (p *ParserContext) byteToLineCol(b int) (int, int) {
+	// binary search over lineStarts
+	lo, hi := 0, len(p.lineStarts)-1
+	for lo <= hi {
+		mid := (lo + hi) >> 1
+		if p.lineStarts[mid] <= b {
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	lineIdx := lo - 1
+	if lineIdx < 0 {
+		lineIdx = 0
+	}
+	lineStart := p.lineStarts[lineIdx]
+	return lineIdx + 1, b - lineStart + 1
+}
+
+// AddPatches appends patches to the context accumulator.
+func (p *ParserContext) AddPatches(ps ...Patch) {
+	p.patches = append(p.patches, ps...)
+}
+
+// Patches returns accumulated patches.
+func (p *ParserContext) Patches() []Patch { return p.patches }
+
+// EvaluateMode controls how #evaluate is handled during traversal.
+type EvaluateMode int
+
+const (
+	EvalOpaque EvaluateMode = iota
+	EvalInspect
+	EvalRewrite
+)
+
+// EvaluateSafety defines safety constraints for handling #evaluate content.
+type EvaluateSafety struct {
+	StringLiteralsOnly bool
+	MaxBytes           int // 0 = unlimited
+}
+
+// EvaluateConfig defines behavior for #evaluate traversal.
+type EvaluateConfig struct {
+	Mode       EvaluateMode
+	DepthLimit int // 0 = unlimited
+	Safety     EvaluateSafety
+	Whitelist  []string // allowed selector IDs for evaluated content
+	Blacklist  []string // disallowed selector IDs
+}

--- a/parser_hooks.go
+++ b/parser_hooks.go
@@ -27,8 +27,13 @@ func applyParserHooks(root *stmt.Block, listener ParserListener, adjuster NodeAd
 func applyParserHooksWithSource(file string, src []byte, root *stmt.Block, listener ParserListener, adjuster NodeAdjuster) (*stmt.Block, error) {
 	ctx := &ParserContext{Scope: NewScope(nil)}
 	ctx.InitSource(file, src)
+	spans := spansFromSource(src)
+	return applyParserHooksWithSourceAndSpans(ctx, root, listener, adjuster, spans)
+}
+
+func applyParserHooksWithSourceAndSpans(ctx *ParserContext, root *stmt.Block, listener ParserListener, adjuster NodeAdjuster, spans map[ast.Node]parser.NodeSpan) (*stmt.Block, error) {
 	// seed spans recorded by the parser into this context
-	for n, s := range parser.Spans() {
+	for n, s := range spans {
 		ctx.SetSpan(n, Span{Start: s.Start, End: s.End})
 	}
 	for i, s := range root.Stmt {
@@ -55,8 +60,24 @@ func applyParserHooksWithConfig(file string, src []byte, root *stmt.Block, liste
 	ctx := &ParserContext{Scope: NewScope(nil)}
 	ctx.InitSource(file, src)
 	ctx.EvalConfig = eval
+	spans := spansFromSource(src)
+	return applyParserHooksWithConfigAndSpans(ctx, root, listener, adjuster, spans, seeds...)
+}
+
+func spansFromSource(src []byte) map[ast.Node]parser.NodeSpan {
+	if len(src) == 0 {
+		return nil
+	}
+	_, spans, err := parser.ParseWithSpansDetailed(src)
+	if err != nil {
+		return nil
+	}
+	return spans
+}
+
+func applyParserHooksWithConfigAndSpans(ctx *ParserContext, root *stmt.Block, listener ParserListener, adjuster NodeAdjuster, spans map[ast.Node]parser.NodeSpan, seeds ...*SymbolSeeds) (*stmt.Block, *ParserContext, error) {
 	// seed spans recorded by the parser into this context
-	for n, s := range parser.Spans() {
+	for n, s := range spans {
 		ctx.SetSpan(n, Span{Start: s.Start, End: s.End})
 	}
 	if len(seeds) > 0 && seeds[0] != nil {
@@ -461,14 +482,17 @@ func handleEvaluate(ev *stmt.Evaluate, listener ParserListener, adjuster NodeAdj
 			return
 		}
 		// Parse and traverse child template with spans to preserve positions
-		block, err := parser.ParseWithSpans(data)
+		block, spans, err := parser.ParseWithSpansDetailed(data)
 		if err != nil {
 			return
 		}
 		// Descend with incremented depth; use synthetic file label
 		saved := ctx.EvalDepth
 		ctx.EvalDepth = saved + 1
-		_, _ = applyParserHooksWithSource(ctx.File+"#eval", data, block, listener, adjuster)
+		childCtx := &ParserContext{Scope: NewScope(nil)}
+		childCtx.InitSource(ctx.File+"#eval", data)
+		childCtx.EvalDepth = ctx.EvalDepth
+		_, _ = applyParserHooksWithSourceAndSpans(childCtx, block, listener, adjuster, spans)
 		ctx.EvalDepth = saved
 	case *aexpr.Select:
 		// Only inspect if allowed by safety and whitelist (no rewrite possible without actual data)

--- a/parser_hooks.go
+++ b/parser_hooks.go
@@ -1,0 +1,506 @@
+package velty
+
+import (
+	"github.com/viant/velty/ast"
+	aexpr "github.com/viant/velty/ast/expr"
+	"github.com/viant/velty/ast/stmt"
+	"github.com/viant/velty/parser"
+	"reflect"
+)
+
+// applyParserHooks traverses the AST, firing listener events and applying adjuster transformations.
+func applyParserHooks(root *stmt.Block, listener ParserListener, adjuster NodeAdjuster) (*stmt.Block, error) {
+	ctx := &ParserContext{Scope: NewScope(nil)}
+	for i, s := range root.Stmt {
+		node, err := walkNode(s, listener, adjuster, ctx)
+		if err != nil {
+			return nil, err
+		}
+		if st, ok := node.(ast.Statement); ok {
+			root.Stmt[i] = st
+		}
+	}
+	return root, nil
+}
+
+// applyParserHooksWithSource initializes context source mapping and then traverses.
+func applyParserHooksWithSource(file string, src []byte, root *stmt.Block, listener ParserListener, adjuster NodeAdjuster) (*stmt.Block, error) {
+	ctx := &ParserContext{Scope: NewScope(nil)}
+	ctx.InitSource(file, src)
+	// seed spans recorded by the parser into this context
+	for n, s := range parser.Spans() {
+		ctx.SetSpan(n, Span{Start: s.Start, End: s.End})
+	}
+	for i, s := range root.Stmt {
+		node, err := walkNode(s, listener, adjuster, ctx)
+		if err != nil {
+			return nil, err
+		}
+		if st, ok := node.(ast.Statement); ok {
+			root.Stmt[i] = st
+		}
+	}
+	return root, nil
+}
+
+// applyParserHooksWithConfig initializes context with source and evaluate config, then traverses.
+type SymbolSeeds struct {
+	Params     []string
+	Namespaces []string
+	Standalone []string
+	Consts     []string
+}
+
+func applyParserHooksWithConfig(file string, src []byte, root *stmt.Block, listener ParserListener, adjuster NodeAdjuster, eval EvaluateConfig, seeds ...*SymbolSeeds) (*stmt.Block, *ParserContext, error) {
+	ctx := &ParserContext{Scope: NewScope(nil)}
+	ctx.InitSource(file, src)
+	ctx.EvalConfig = eval
+	// seed spans recorded by the parser into this context
+	for n, s := range parser.Spans() {
+		ctx.SetSpan(n, Span{Start: s.Start, End: s.End})
+	}
+	if len(seeds) > 0 && seeds[0] != nil {
+		s := seeds[0]
+		ctx.SeedSymbols(s.Params, s.Namespaces, s.Standalone, s.Consts)
+	}
+	for i, s := range root.Stmt {
+		node, err := walkNode(s, listener, adjuster, ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if st, ok := node.(ast.Statement); ok {
+			root.Stmt[i] = st
+		}
+	}
+	return root, ctx, nil
+}
+
+// walkNode processes a single AST node: fire enter/exit events and apply adjuster.
+func walkNode(n ast.Node, listener ParserListener, adjuster NodeAdjuster, ctx *ParserContext) (ast.Node, error) {
+	// build event with span/position if available
+	enter := Event{Type: EventEnterNode, Node: n, Context: ctx, ExprContext: ctx.CurrentExprContext()}
+	if s, ok := ctx.GetSpan(n); ok {
+		enter.Span = s
+		enter.Position = ctx.ResolvePosition(s)
+	}
+	if listener != nil {
+		listener.OnEvent(enter)
+	}
+	ctx.PushNode(n)
+	if adjuster != nil {
+		act, err := adjuster.Adjust(n, ctx)
+		if err != nil {
+			return nil, err
+		}
+		switch act.Kind {
+		case ActionRemove:
+			// do not traverse children; exit event will still fire with nil Node
+			ctx.PopNode()
+			if listener != nil {
+				listener.OnEvent(Event{Type: EventExitNode, Node: n, Context: ctx, ExprContext: ctx.CurrentExprContext()})
+			}
+			return nil, nil
+		case ActionReplace:
+			if act.Node != nil {
+				n = act.Node
+			}
+			if act.SkipChildren {
+				// skip traversing children
+				ctx.PopNode()
+				if listener != nil {
+					listener.OnEvent(Event{Type: EventExitNode, Node: n, Context: ctx, ExprContext: ctx.CurrentExprContext()})
+				}
+				return n, nil
+			}
+		case ActionPatchOnly:
+			if act.SkipChildren {
+				ctx.PopNode()
+				if listener != nil {
+					listener.OnEvent(Event{Type: EventExitNode, Node: n, Context: ctx, ExprContext: ctx.CurrentExprContext()})
+				}
+				return n, nil
+			}
+		case ActionKeep:
+			// continue
+		}
+	}
+	switch node := n.(type) {
+	case *stmt.Block:
+		for i, child := range node.Stmt {
+			newChild, err := walkNode(child, listener, adjuster, ctx)
+			if err != nil {
+				return nil, err
+			}
+			if newChild == nil {
+				// removal: drop child
+				node.Stmt = append(node.Stmt[:i], node.Stmt[i+1:]...)
+				i--
+				continue
+			}
+			if st, ok := newChild.(ast.Statement); ok {
+				node.Stmt[i] = st
+			}
+		}
+	case *stmt.If:
+		// Distinguish top-level if from synthetic else-body wrappers.
+		switch ctx.CurrentExprContext().Kind {
+		case CtxElseBody:
+			// Synthetic If created for #else: we want body selectors to see CtxElseBody.
+			for i, child := range node.Body.Stmt {
+				newChild, err := walkNode(child, listener, adjuster, ctx)
+				if err != nil {
+					return nil, err
+				}
+				if newChild == nil {
+					node.Body.Stmt = append(node.Body.Stmt[:i], node.Body.Stmt[i+1:]...)
+					i--
+					continue
+				}
+				if st, ok := newChild.(ast.Statement); ok {
+					node.Body.Stmt[i] = st
+				}
+			}
+		default:
+			// Regular if/elseif chains.
+			// If condition
+			ctx.PushExprContext(ExprContext{Kind: CtxIfCond, ArgIdx: -1})
+			_ = walkExpr(node.Condition, listener, adjuster, ctx)
+			ctx.PopExprContext()
+
+			// If body
+			ctx.PushExprContext(ExprContext{Kind: CtxIfBody, ArgIdx: -1})
+			for i, child := range node.Body.Stmt {
+				newChild, err := walkNode(child, listener, adjuster, ctx)
+				if err != nil {
+					return nil, err
+				}
+				if newChild == nil {
+					node.Body.Stmt = append(node.Body.Stmt[:i], node.Body.Stmt[i+1:]...)
+					i--
+					continue
+				}
+				if st, ok := newChild.(ast.Statement); ok {
+					node.Body.Stmt[i] = st
+				}
+			}
+			ctx.PopExprContext()
+
+			if node.Else != nil {
+				// Else branch can represent either else-if (Condition != nil) or else body
+				if node.Else.Condition != nil {
+					// Else-if condition
+					ctx.PushExprContext(ExprContext{Kind: CtxElseIfCond, ArgIdx: -1})
+					_ = walkExpr(node.Else.Condition, listener, adjuster, ctx)
+					ctx.PopExprContext()
+
+					// Else-if body
+					ctx.PushExprContext(ExprContext{Kind: CtxIfBody, ArgIdx: -1})
+					for i, child := range node.Else.Body.Stmt {
+						newChild, err := walkNode(child, listener, adjuster, ctx)
+						if err != nil {
+							return nil, err
+						}
+						if newChild == nil {
+							node.Else.Body.Stmt = append(node.Else.Body.Stmt[:i], node.Else.Body.Stmt[i+1:]...)
+							i--
+							continue
+						}
+						if st, ok := newChild.(ast.Statement); ok {
+							node.Else.Body.Stmt[i] = st
+						}
+					}
+					ctx.PopExprContext()
+				} else {
+					// Plain else body
+					ctx.PushExprContext(ExprContext{Kind: CtxElseBody, ArgIdx: -1})
+					if _, err := walkNode(node.Else, listener, adjuster, ctx); err != nil {
+						return nil, err
+					}
+					ctx.PopExprContext()
+				}
+			}
+		}
+	case *stmt.ForEach:
+		// foreach iterable expression
+		ctx.PushExprContext(ExprContext{Kind: CtxForEachCond, ArgIdx: -1})
+		_ = walkExpr(node.Set, listener, adjuster, ctx)
+		ctx.PopExprContext()
+
+		// Enter new scope and mark foreach item as local
+		ctx.EnterScope()
+		if node.Item != nil && node.Item.ID != "" {
+			ctx.MarkLocal(node.Item.ID)
+		}
+
+		// foreach body
+		ctx.PushExprContext(ExprContext{Kind: CtxForEachBody, ArgIdx: -1})
+		for i, child := range node.Body.Stmt {
+			newChild, err := walkNode(child, listener, adjuster, ctx)
+			if err != nil {
+				return nil, err
+			}
+			if newChild == nil {
+				node.Body.Stmt = append(node.Body.Stmt[:i], node.Body.Stmt[i+1:]...)
+				i--
+				continue
+			}
+			if st, ok := newChild.(ast.Statement); ok {
+				node.Body.Stmt[i] = st
+			}
+		}
+		ctx.PopExprContext()
+		ctx.ExitScope()
+	case *stmt.ForLoop:
+		if node.Init != nil {
+			if initNode, ok := node.Init.(ast.Node); ok {
+				ctx.PushExprContext(ExprContext{Kind: CtxForLoopInit, ArgIdx: -1})
+				newInit, err := walkNode(initNode, listener, adjuster, ctx)
+				ctx.PopExprContext()
+				if err != nil {
+					return nil, err
+				}
+				if newInit == nil {
+					node.Init = nil
+				} else if st, ok2 := newInit.(ast.Statement); ok2 {
+					node.Init = st
+				}
+			}
+		}
+		if node.Cond != nil {
+			ctx.PushExprContext(ExprContext{Kind: CtxForLoopCond, ArgIdx: -1})
+			_ = walkExpr(node.Cond, listener, adjuster, ctx)
+			ctx.PopExprContext()
+		}
+		if node.Post != nil {
+			if postNode, ok := node.Post.(ast.Node); ok {
+				ctx.PushExprContext(ExprContext{Kind: CtxForLoopPost, ArgIdx: -1})
+				if _, err := walkNode(postNode, listener, adjuster, ctx); err != nil {
+					ctx.PopExprContext()
+					return nil, err
+				}
+				ctx.PopExprContext()
+			}
+		}
+		for i, child := range node.Body.Stmt {
+			newChild, err := walkNode(child, listener, adjuster, ctx)
+			if err != nil {
+				return nil, err
+			}
+			if st, ok := newChild.(ast.Statement); ok {
+				node.Body.Stmt[i] = st
+			}
+		}
+	case *stmt.Evaluate:
+		handleEvaluate(node, listener, adjuster, ctx)
+	case *stmt.Statement:
+		if node.X != nil {
+			ctx.PushExprContext(ExprContext{Kind: CtxSetLHS, ArgIdx: -1})
+			_ = walkExpr(node.X, listener, adjuster, ctx)
+			ctx.PopExprContext()
+			// Record #set local variable on assignment when LHS is a selector name
+			if sel, ok := node.X.(*aexpr.Select); ok {
+				ctx.MarkLocal(sel.ID)
+			}
+		}
+		if node.Y != nil {
+			ctx.PushExprContext(ExprContext{Kind: CtxSetRHS, ArgIdx: -1})
+			_ = walkExpr(node.Y, listener, adjuster, ctx)
+			ctx.PopExprContext()
+		}
+	case *stmt.Append:
+		// plain text context for this node
+		ctx.PushExprContext(ExprContext{Kind: CtxPlainText, ArgIdx: -1})
+		ctx.PopExprContext()
+	}
+	ctx.PopNode()
+	exit := Event{Type: EventExitNode, Node: n, Context: ctx, ExprContext: ctx.CurrentExprContext()}
+	if s, ok := ctx.GetSpan(n); ok {
+		exit.Span = s
+		exit.Position = ctx.ResolvePosition(s)
+	}
+	if listener != nil {
+		listener.OnEvent(exit)
+	}
+	return n, nil
+}
+
+// walkExpr traverses expression AST and fires events/adjusters via synthetic nodes.
+func walkExpr(e ast.Expression, listener ParserListener, adjuster NodeAdjuster, ctx *ParserContext) ast.Expression {
+	if e == nil {
+		return nil
+	}
+	// If no explicit context has been set, treat as append expression.
+	if ctx.CurrentExprContext().Kind == CtxUnknown {
+		ctx.PushExprContext(ExprContext{Kind: CtxAppendExpr, ArgIdx: -1})
+		defer ctx.PopExprContext()
+	}
+
+	// Track per-name occurrence for selectors.
+	occ := 0
+	if sel, ok := e.(*aexpr.Select); ok {
+		occ = ctx.BumpOccurrence(sel.ID)
+	}
+
+	evEnter := Event{Type: EventEnterNode, Node: e, Context: ctx, ExprContext: ctx.CurrentExprContext(), Occurrence: occ}
+	if s, ok := ctx.GetSpan(e); ok {
+		evEnter.Span = s
+		evEnter.Position = ctx.ResolvePosition(s)
+	}
+	if listener != nil {
+		listener.OnEvent(evEnter)
+	}
+	if adjuster != nil {
+		act, err := adjuster.Adjust(e, ctx)
+		if err == nil {
+			switch act.Kind {
+			case ActionReplace:
+				if ex, ok := act.Node.(ast.Expression); ok {
+					e = ex
+				}
+				if act.SkipChildren {
+					ev := Event{Type: EventExitNode, Node: e, Context: ctx, ExprContext: ctx.CurrentExprContext(), Occurrence: occ}
+					if s, ok := ctx.GetSpan(e); ok {
+						ev.Span = s
+						ev.Position = ctx.ResolvePosition(s)
+					}
+					if listener != nil {
+						listener.OnEvent(ev)
+					}
+					return e
+				}
+			case ActionRemove:
+				ev := Event{Type: EventExitNode, Node: e, Context: ctx, ExprContext: ctx.CurrentExprContext(), Occurrence: occ}
+				if s, ok := ctx.GetSpan(e); ok {
+					ev.Span = s
+					ev.Position = ctx.ResolvePosition(s)
+				}
+				if listener != nil {
+					listener.OnEvent(ev)
+				}
+				return nil
+			case ActionPatchOnly:
+				if act.SkipChildren {
+					ev := Event{Type: EventExitNode, Node: e, Context: ctx, ExprContext: ctx.CurrentExprContext(), Occurrence: occ}
+					if s, ok := ctx.GetSpan(e); ok {
+						ev.Span = s
+						ev.Position = ctx.ResolvePosition(s)
+					}
+					if listener != nil {
+						listener.OnEvent(ev)
+					}
+					return e
+				}
+			case ActionKeep:
+				// continue
+			}
+		}
+	}
+	switch x := e.(type) {
+	case *aexpr.Select:
+		if x.X != nil {
+			_ = walkExpr(x.X, listener, adjuster, ctx)
+		}
+	case *aexpr.Call:
+		for i := range x.Args {
+			ctx.PushExprContext(ExprContext{Kind: CtxFuncArg, ArgIdx: int16(i)})
+			_ = walkExpr(x.Args[i], listener, adjuster, ctx)
+			ctx.PopExprContext()
+		}
+		if x.X != nil {
+			_ = walkExpr(x.X, listener, adjuster, ctx)
+		}
+	case *aexpr.Binary:
+		_ = walkExpr(x.X, listener, adjuster, ctx)
+		_ = walkExpr(x.Y, listener, adjuster, ctx)
+	case *aexpr.Unary:
+		_ = walkExpr(x.X, listener, adjuster, ctx)
+	case *aexpr.Parentheses:
+		_ = walkExpr(x.P, listener, adjuster, ctx)
+	case *aexpr.Range:
+		// literals are terminal
+	case *aexpr.Literal:
+		// terminal
+	}
+	evExit := Event{Type: EventExitNode, Node: e, Context: ctx, ExprContext: ctx.CurrentExprContext(), Occurrence: occ}
+	if s, ok := ctx.GetSpan(e); ok {
+		evExit.Span = s
+		evExit.Position = ctx.ResolvePosition(s)
+	}
+	if listener != nil {
+		listener.OnEvent(evExit)
+	}
+	return e
+}
+
+// handleEvaluate applies Evaluate handling respecting context configuration.
+func handleEvaluate(ev *stmt.Evaluate, listener ParserListener, adjuster NodeAdjuster, ctx *ParserContext) {
+	// Always emit events for the Evaluate node expression itself
+	ctx.PushExprContext(ExprContext{Kind: CtxEvaluate, ArgIdx: -1})
+	_ = walkExpr(ev.X, listener, adjuster, ctx)
+	ctx.PopExprContext()
+
+	mode := ctx.EvalConfig.Mode
+	if mode == EvalOpaque {
+		return
+	}
+	// depth guard
+	if ctx.EvalConfig.DepthLimit > 0 && ctx.EvalDepth >= ctx.EvalConfig.DepthLimit {
+		// emit nothing further in inspect/rewrite when depth exceeded
+		return
+	}
+
+	// Only allow string literal input unless safety permits selector whitelisting
+	switch x := ev.X.(type) {
+	case *aexpr.Literal:
+		// ensure it's a string literal
+		if x.RType == nil || x.RType.Kind() != reflect.String {
+			return
+		}
+		data := []byte(x.Value)
+		if max := ctx.EvalConfig.Safety.MaxBytes; max > 0 && len(data) > max {
+			return
+		}
+		// Parse and traverse child template with spans to preserve positions
+		block, err := parser.ParseWithSpans(data)
+		if err != nil {
+			return
+		}
+		// Descend with incremented depth; use synthetic file label
+		saved := ctx.EvalDepth
+		ctx.EvalDepth = saved + 1
+		_, _ = applyParserHooksWithSource(ctx.File+"#eval", data, block, listener, adjuster)
+		ctx.EvalDepth = saved
+	case *aexpr.Select:
+		// Only inspect if allowed by safety and whitelist (no rewrite possible without actual data)
+		if ctx.EvalConfig.Safety.StringLiteralsOnly {
+			return
+		}
+		id := x.ID
+		if len(ctx.EvalConfig.Whitelist) > 0 && !contains(ctx.EvalConfig.Whitelist, id) {
+			return
+		}
+		if contains(ctx.EvalConfig.Blacklist, id) {
+			return
+		}
+		// In Inspect mode we do nothing more; in Rewrite mode as well, since we can't parse dynamic content here
+		return
+	default:
+		// other dynamic expressions ignored
+		return
+	}
+}
+
+func reflectStringKind() int {
+	// local helper to avoid importing reflect here explicitly
+	// reflect.String has Kind() == 24; but safer is to use reflect in top scope; compromise: return 24
+	return 24
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/patches.go
+++ b/patches.go
@@ -1,0 +1,59 @@
+package velty
+
+import "sort"
+
+// ApplyPatches applies a set of textual replacements to src according to
+// Patch spans and returns a new byte slice. Spans are interpreted using the
+// same convention as parser spans: [Start, End] (inclusive end offset).
+//
+// Callers are expected to provide non-overlapping patches relative to the
+// original src. Overlapping or out-of-range patches are ignored.
+func ApplyPatches(src []byte, patches []Patch) []byte {
+	if len(patches) == 0 {
+		// preserve src immutability by returning a copy
+		dst := make([]byte, len(src))
+		copy(dst, src)
+		return dst
+	}
+
+	// work on a copy to avoid mutating caller slice
+	ps := make([]Patch, len(patches))
+	copy(ps, patches)
+
+	sort.Slice(ps, func(i, j int) bool { return ps[i].Span.Start < ps[j].Span.Start })
+
+	// conservative capacity: original size; may grow if replacements are larger
+	out := make([]byte, 0, len(src))
+	last := 0
+
+	for _, p := range ps {
+		start := p.Span.Start
+		// spans from parser are [start,end] inclusive; convert to [start,endExcl)
+		endExcl := p.Span.End + 1
+
+		// basic validation and non-overlap guarantee relative to original src
+		if start < last || start < 0 || endExcl < start || endExcl > len(src) {
+			// skip invalid/overlapping patch
+			continue
+		}
+
+		// copy unchanged region
+		if start > last {
+			out = append(out, src[last:start]...)
+		}
+
+		// apply replacement
+		if len(p.Replacement) > 0 {
+			out = append(out, p.Replacement...)
+		}
+
+		last = endExcl
+	}
+
+	// append remaining tail
+	if last < len(src) {
+		out = append(out, src[last:]...)
+	}
+
+	return out
+}

--- a/planner.go
+++ b/planner.go
@@ -31,6 +31,14 @@ type (
 		escapeHTML   bool
 		panicOnError bool
 		nodeSeq      int
+		// listener receives parse events (reserved for future use)
+		listener ParserListener
+		// adjuster applies node transformations (reserved for future use)
+		adjuster NodeAdjuster
+		// evaluate traversal configuration
+		evalConfig EvaluateConfig
+		// planListener receives binding/type resolution hooks
+		planListener PlannerListener
 	}
 )
 
@@ -188,10 +196,16 @@ func (p *Planner) DefineVariable(name string, v interface{}, names ...string) er
 	if err := p.addSelectors("", field, name); err != nil {
 		return err
 	}
+	if p.planListener != nil {
+		p.planListener.OnDefineVariable(name, sType)
+	}
 
 	for _, additionalFieldName := range names {
 		if err := p.addSelectors("", field, additionalFieldName); err != nil {
 			return err
+		}
+		if p.planListener != nil {
+			p.planListener.OnDefineVariable(additionalFieldName, sType)
 		}
 	}
 
@@ -420,6 +434,13 @@ func (p *Planner) newFuncSelector(selectorId string, methodName string, call *ex
 			newSelector.Type = actualType
 		}
 	}
+	if p.planListener != nil {
+		var recvType reflect.Type
+		if prev != nil {
+			recvType = prev.Type
+		}
+		p.planListener.OnFunctionBind(methodName, aFunc, recvType)
+	}
 
 	return newSelector, nil
 }
@@ -514,6 +535,18 @@ func (p *Planner) apply(options []Option) {
 			if p.Functions == nil {
 				p.Functions = actual
 			}
+		case Listener:
+			p.listener = ParserListener(actual)
+		case Adjuster:
+			p.adjuster = NodeAdjuster(actual)
+		case Policies:
+			if reg := (*PolicyRegistry)(actual); reg != nil {
+				p.adjuster = reg.AsAdjuster()
+			}
+		case EvalCfg:
+			p.evalConfig = EvaluateConfig(actual)
+		case PlanHooks:
+			p.planListener = PlannerListener(actual)
 		}
 	}
 }

--- a/planner_listener.go
+++ b/planner_listener.go
@@ -1,0 +1,18 @@
+package velty
+
+import (
+	"github.com/viant/velty/est/op"
+	"reflect"
+)
+
+// PlannerListener receives hooks during planning/binding (post-parse).
+type PlannerListener interface {
+	// OnDefineVariable is called when a planner defines a top-level variable.
+	OnDefineVariable(name string, rtype reflect.Type)
+	// OnSelectorResolved is called when an expression resolves to a selector.
+	OnSelectorResolved(sel *op.Selector)
+	// OnFunctionBind is called when a function/method is bound.
+	OnFunctionBind(name string, f *op.Func, receiverType reflect.Type)
+	// OnForEachResolved is called when a foreach item is resolved with types.
+	OnForEachResolved(itemName string, itemType, setType reflect.Type)
+}

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,72 @@
+package velty
+
+import (
+	"github.com/viant/velty/ast"
+	"reflect"
+)
+
+// PolicyKind is a string label for node kinds (e.g., "Selector", "Call", "If", "ForEach", ...)
+type PolicyKind string
+
+// Policy represents a composable rule applied over nodes with metadata.
+type Policy interface {
+	// Name is the policy identifier.
+	Name() string
+	// Priority defines policy ordering (lower first).
+	Priority() int
+	// Enabled reports whether policy is active.
+	Enabled() bool
+	// Match selects nodes/contexts this policy applies to.
+	Match(node ast.Node, ctx *ParserContext) bool
+	// Apply executes policy logic and returns an action.
+	Apply(node ast.Node, ctx *ParserContext) (Action, error)
+}
+
+// NodeKindOf returns a coarse node kind name for policies.
+func NodeKindOf(n ast.Node) PolicyKind {
+	if n == nil {
+		return ""
+	}
+	t := reflect.TypeOf(n)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return PolicyKind(t.Name())
+}
+
+// BasicPolicy is a helper policy base with simple filters and a function logic.
+type BasicPolicy struct {
+	ID       string
+	Order    int
+	Active   bool
+	Kinds    []PolicyKind // optional node kinds filter
+	Contexts []string     // optional context kinds (reserved)
+	Fn       func(node ast.Node, ctx *ParserContext) (Action, error)
+}
+
+func (p *BasicPolicy) Name() string  { return p.ID }
+func (p *BasicPolicy) Priority() int { return p.Order }
+func (p *BasicPolicy) Enabled() bool { return p.Active }
+
+func (p *BasicPolicy) Match(node ast.Node, ctx *ParserContext) bool {
+	if !p.Active {
+		return false
+	}
+	if len(p.Kinds) == 0 {
+		return true
+	}
+	kind := NodeKindOf(node)
+	for _, k := range p.Kinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *BasicPolicy) Apply(node ast.Node, ctx *ParserContext) (Action, error) {
+	if p.Fn == nil {
+		return Keep(), nil
+	}
+	return p.Fn(node, ctx)
+}

--- a/pool_reuse_test.go
+++ b/pool_reuse_test.go
@@ -1,0 +1,27 @@
+package velty
+
+import (
+	"testing"
+)
+
+func TestPool_ReusesStateAfterPut(t *testing.T) {
+	planner := New()
+	if err := planner.DefineVariable("foo", ""); err != nil {
+		t.Fatalf("define variable: %v", err)
+	}
+	_, newState, err := planner.Compile([]byte("$foo"))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	pool := NewPool(1, newState)
+
+	s1 := pool.State()
+	pool.Put(s1)
+
+	s2 := pool.State()
+	if s1 != s2 {
+		t.Fatalf("expected pool to reuse state instance")
+	}
+	pool.Put(s2)
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,97 @@
+package velty
+
+import (
+	"github.com/viant/velty/ast"
+	"sort"
+)
+
+// PolicyRegistry stores and applies policies in priority order.
+type PolicyRegistry struct {
+	items []Policy
+	idx   map[string]int
+}
+
+func NewPolicyRegistry() *PolicyRegistry {
+	return &PolicyRegistry{items: make([]Policy, 0, 8), idx: map[string]int{}}
+}
+
+// Register adds or replaces a policy by name.
+func (r *PolicyRegistry) Register(p Policy) {
+	if p == nil {
+		return
+	}
+	if i, ok := r.idx[p.Name()]; ok {
+		r.items[i] = p
+		r.sort()
+		return
+	}
+	r.items = append(r.items, p)
+	r.idx[p.Name()] = len(r.items) - 1
+	r.sort()
+}
+
+// Enable toggles a policy by name when it implements BasicPolicy convention.
+func (r *PolicyRegistry) Enable(name string, on bool) {
+	if i, ok := r.idx[name]; ok {
+		// best effort: attempt to toggle Active if policy is *BasicPolicy
+		if bp, ok2 := r.items[i].(*BasicPolicy); ok2 {
+			bp.Active = on
+		}
+	}
+}
+
+func (r *PolicyRegistry) Policies() []Policy { return r.items }
+
+func (r *PolicyRegistry) sort() {
+	sort.SliceStable(r.items, func(i, j int) bool { return r.items[i].Priority() < r.items[j].Priority() })
+	// rebuild index
+	for i := range r.items {
+		r.idx[r.items[i].Name()] = i
+	}
+}
+
+// AsAdjuster builds a NodeAdjuster that evaluates registered policies.
+func (r *PolicyRegistry) AsAdjuster() NodeAdjuster {
+	return AdjustFunc(func(node ast.Node, ctx *ParserContext) (Action, error) {
+		var replaced ast.Node = node
+		skipChildren := false
+		for _, p := range r.items {
+			if !p.Enabled() {
+				continue
+			}
+			if !p.Match(replaced, ctx) {
+				continue
+			}
+			act, err := p.Apply(replaced, ctx)
+			if err != nil {
+				return Action{}, err
+			}
+			if len(act.Patches) > 0 {
+				ctx.AddPatches(act.Patches...)
+			}
+			switch act.Kind {
+			case ActionKeep:
+				// continue to next policy
+			case ActionRemove:
+				return act, nil
+			case ActionReplace:
+				if act.Node != nil {
+					replaced = act.Node
+				}
+				if act.SkipChildren {
+					skipChildren = true
+				}
+			case ActionPatchOnly:
+				if act.SkipChildren {
+					skipChildren = true
+				}
+			}
+		}
+		if replaced != node || skipChildren {
+			res := Replace(replaced)
+			res.SkipChildren = skipChildren
+			return res, nil
+		}
+		return Keep(), nil
+	})
+}

--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,42 @@
+package velty
+
+// Severity level for diagnostics.
+type Severity int
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarning
+	SeverityError
+)
+
+// ErrorRecord captures a diagnostic with optional span/position.
+type ErrorRecord struct {
+	Severity Severity
+	Code     string
+	Message  string
+	File     string
+	Span     Span
+	Position Position
+	Policy   string
+	// Optional node/context info
+	NodeKind string
+	NodeID   int
+	// SelectorChain may carry $foo.bar.baz chain segments if available
+	SelectorChain []string
+}
+
+// Reporter accumulates diagnostics and can flush them to a sink.
+type Reporter struct {
+	records []ErrorRecord
+}
+
+func NewReporter() *Reporter { return &Reporter{records: make([]ErrorRecord, 0, 16)} }
+
+// Report appends a diagnostic record.
+func (r *Reporter) Report(rec ErrorRecord) { r.records = append(r.records, rec) }
+
+// Records returns current diagnostics.
+func (r *Reporter) Records() []ErrorRecord { return r.records }
+
+// Reset clears buffered diagnostics.
+func (r *Reporter) Reset() { r.records = r.records[:0] }

--- a/selector.go
+++ b/selector.go
@@ -21,6 +21,9 @@ func (p *Planner) selectorExpr(selector *expr.Select) (*op.Expression, error) {
 		expression.Selector.Placeholder = selector.FullName
 	}
 
+	if p.planListener != nil && expression.Selector != nil {
+		p.planListener.OnSelectorResolved(expression.Selector)
+	}
 	expression.Type = expression.Selector.Type
 	return expression, nil
 }

--- a/spans_test.go
+++ b/spans_test.go
@@ -1,0 +1,31 @@
+package velty
+
+import (
+	"github.com/stretchr/testify/require"
+	aexpr "github.com/viant/velty/ast/expr"
+	"testing"
+)
+
+type captureListener struct{ events []Event }
+
+func (c *captureListener) OnEvent(e Event) { c.events = append(c.events, e) }
+
+func TestParserSpansPositions(t *testing.T) {
+	tpl := []byte("hello\n$foo.Bar(42)[0]\nworld")
+	cap := &captureListener{}
+	p := New(Listener(cap))
+	_, _, err := p.Compile(tpl)
+	require.NoError(t, err)
+
+	// find a Select event with non-zero positions
+	var selPos Position
+	for _, ev := range cap.events {
+		switch ev.Node.(type) {
+		case *aexpr.Select:
+			if ev.Position.Line != 0 || ev.Position.Col != 0 {
+				selPos = ev.Position
+			}
+		}
+	}
+	require.NotZero(t, selPos.Line, "selector position should be populated")
+}

--- a/stmt.go
+++ b/stmt.go
@@ -135,8 +135,10 @@ func (p *Planner) compileForEachLoop(actual *stmt2.ForEach) (est.New, error) {
 	}
 
 	// Define $foreach context similar to Apache Velocity: index, count, hasNext, first, last.
-	// Must match runtime loop writer type in est/stmt.
-	_ = p.DefineVariable("foreach", stmt.ForEachInfo{})
+	// Register once per planner to avoid redundant selector tree construction.
+	if p.selectorByName("foreach") == nil {
+		_ = p.DefineVariable("foreach", stmt.ForEachInfo{})
+	}
 
 	selector, err := p.compileExpr(actual.Item)
 	if err != nil {

--- a/stmt.go
+++ b/stmt.go
@@ -130,6 +130,9 @@ func (p *Planner) compileForEachLoop(actual *stmt2.ForEach) (est.New, error) {
 	if err := p.DefineVariable(actual.Item.ID, itemType); err != nil {
 		return nil, err
 	}
+	if p.planListener != nil {
+		p.planListener.OnForEachResolved(actual.Item.ID, itemType, sliceSelector.Type)
+	}
 
 	// Define $foreach context similar to Apache Velocity: index, count, hasNext, first, last
 	// If already defined, DefineVariable is a no-op.

--- a/stmt.go
+++ b/stmt.go
@@ -134,9 +134,9 @@ func (p *Planner) compileForEachLoop(actual *stmt2.ForEach) (est.New, error) {
 		p.planListener.OnForEachResolved(actual.Item.ID, itemType, sliceSelector.Type)
 	}
 
-	// Define $foreach context similar to Apache Velocity: index, count, hasNext, first, last
-	// If already defined, DefineVariable is a no-op.
-	_ = p.DefineVariable("foreach", ForEachInfo{})
+	// Define $foreach context similar to Apache Velocity: index, count, hasNext, first, last.
+	// Must match runtime loop writer type in est/stmt.
+	_ = p.DefineVariable("foreach", stmt.ForEachInfo{})
 
 	selector, err := p.compileExpr(actual.Item)
 	if err != nil {

--- a/transform.go
+++ b/transform.go
@@ -12,7 +12,7 @@ func TransformTemplate(src []byte, adjuster NodeAdjuster, evalCfg ...EvaluateCon
 		copy(dst, src)
 		return dst, nil
 	}
-	root, err := parser.ParseWithSpans(src)
+	root, spans, err := parser.ParseWithSpansDetailed(src)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,10 @@ func TransformTemplate(src []byte, adjuster NodeAdjuster, evalCfg ...EvaluateCon
 		cfg = evalCfg[0]
 	}
 	// Use adjuster chain so action patches are accumulated into parser context.
-	_, ctx, err := applyParserHooksWithConfig("", src, root, nil, NewAdjusterChain(adjuster), cfg)
+	hookCtx := &ParserContext{Scope: NewScope(nil)}
+	hookCtx.InitSource("", src)
+	hookCtx.EvalConfig = cfg
+	_, ctx, err := applyParserHooksWithConfigAndSpans(hookCtx, root, nil, NewAdjusterChain(adjuster), spans)
 	if err != nil {
 		return nil, err
 	}

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,29 @@
+package velty
+
+import (
+	"github.com/viant/velty/parser"
+)
+
+// TransformTemplate parses a template with spans, runs the supplied adjuster,
+// and applies accumulated text patches to return transformed source.
+func TransformTemplate(src []byte, adjuster NodeAdjuster, evalCfg ...EvaluateConfig) ([]byte, error) {
+	if len(src) == 0 || adjuster == nil {
+		dst := make([]byte, len(src))
+		copy(dst, src)
+		return dst, nil
+	}
+	root, err := parser.ParseWithSpans(src)
+	if err != nil {
+		return nil, err
+	}
+	cfg := EvaluateConfig{}
+	if len(evalCfg) > 0 {
+		cfg = evalCfg[0]
+	}
+	// Use adjuster chain so action patches are accumulated into parser context.
+	_, ctx, err := applyParserHooksWithConfig("", src, root, nil, NewAdjusterChain(adjuster), cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ApplyPatches(src, ctx.Patches()), nil
+}


### PR DESCRIPTION
Adds parser instrumentation framework:

Listener and Adjuster options.
Policy/registry/reporter/action model for parser-time transformations and diagnostics.
TransformTemplate support for source-to-source rewrite via patches.
Adds context-aware execution:

est.State carries context.Context.
Execution.ExecWithContext(ctx, state) introduced.
Functions/methods with context.Context as first param are auto-injected from state context.
Improves parser/planner capabilities:

Span capture support for AST nodes.
Expanded selector/call/index matching logic.
Planner hook callbacks for variable/function/foreach resolution.
Adds foreach runtime context:

$foreach data (index, count, hasNext, first, last) during loop execution.
Updates truthiness handling in if evaluation:

More explicit coercion behavior for slices/strings/numbers/pointers.
Special handling for pointer-to-struct with IsZero/Zero methods.
Adds substantial test and benchmark coverage:

New tests for context passing, foreach context, unary/if behavior, parser spans, pointer/slice/map selectors.
Added benchmark artifacts/scripts.
Concurrency-safety hardening for parser spans (follow-up in this branch):

Removed global parse span state.
Switched to per-parse span ownership and explicit span propagation through hook paths.
Pool/session lifecycle fixes (follow-up in this branch):

State.Reset() now restores context.Background().
State.Reset() now marks pooled state reusable (isTaken = false).
Added pool reuse regression test.
Performance outcome on your production VM corpus ([*.vm](app://-/index.html#)):

Compile behavior: all templates compile on both branches.
Final compile benchmark is effectively at parity/slightly better than main (no material regression).